### PR TITLE
docs(tests/vm): VM 스왑 및 정렬 관련 테스트 파일에 한국어 주석 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,33 @@ Thumbs.db
 # 빌드 디렉토리 (예: makefile 빌드 시 사용)
 build/
 bin/
+
+# Clion cmake build folder
+/cmake-build-debug/
+/cmake-build-debug--/
+/cmake-build-release/
+.idea
+/CMakeFiles
+
+# Clion cmake build file
+CMakeLists.txt
+CMakeCache.txt
+cmake_install.cmake
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+# MacOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+
+.gitignore
+.gitconfig

--- a/include/lib/kernel/hash.h
+++ b/include/lib/kernel/hash.h
@@ -19,6 +19,21 @@
  * that contains it.  This is the same technique used in the
  * linked list implementation.  Refer to lib/kernel/list.h for a
  * detailed explanation. */
+/* 해시 테이블
+ *
+ * 이 자료 구조는 프로젝트 3을 위한 Pintos Tour 문서에 자세히 설명되어 있습니다.
+ *
+ * 이것은 체이닝을 사용하는 표준 해시 테이블입니다. 테이블에서 요소를 찾기 위해,
+ * 요소의 데이터에 대한 해시 함수를 계산하고 그것을 이중 연결 리스트 배열의
+ * 인덱스로 사용한 다음, 해당 리스트를 선형으로 검색합니다.
+ *
+ * 체인 리스트는 동적 할당을 사용하지 않습니다. 대신, 해시에 포함될 가능성이 있는
+ * 각 구조체는 `struct hash_elem` 멤버를 내장해야 합니다. 모든 해시 함수는
+ * 이러한 `struct hash_elem`에 대해 작동합니다. `hash_entry` 매크로는
+ * `struct hash_elem`에서 그것을 포함하는 구조체 객체로 다시 변환할 수 있게
+ * 해줍니다. 이것은 연결 리스트 구현에서 사용된 것과 동일한 기법입니다.
+ * 자세한 설명은 `lib/kernel/list.h`를 참조하십시오.
+ */
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -26,8 +41,9 @@
 #include "list.h"
 
 /* Hash element. */
+// 해시 요소.
 struct hash_elem {
-	struct list_elem list_elem;
+    struct list_elem list_elem;
 };
 
 /* Converts pointer to hash element HASH_ELEM into a pointer to
@@ -35,66 +51,91 @@ struct hash_elem {
  * name of the outer structure STRUCT and the member name MEMBER
  * of the hash element.  See the big comment at the top of the
  * file for an example. */
+/* 해시 요소 HASH_ELEM을 가리키는 포인터를 HASH_ELEM이 내장된
+ * 구조체를 가리키는 포인터로 변환합니다. 외부 구조체의 이름 STRUCT와
+ * 해시 요소의 멤버 이름 MEMBER를 제공하십시오. 예시는 파일 상단의
+ * 큰 주석을 참조하십시오. */
 #define hash_entry(HASH_ELEM, STRUCT, MEMBER)                   \
-	((STRUCT *) ((uint8_t *) &(HASH_ELEM)->list_elem        \
-		- offsetof (STRUCT, MEMBER.list_elem)))
+    ((STRUCT *) ((uint8_t *) &(HASH_ELEM)->list_elem        \
+       - offsetof (STRUCT, MEMBER.list_elem)))
 
 /* Computes and returns the hash value for hash element E, given
  * auxiliary data AUX. */
+// 보조 데이터 AUX가 주어졌을 때, 해시 요소 E에 대한 해시 값을 계산하고 반환합니다.
 typedef uint64_t hash_hash_func (const struct hash_elem *e, void *aux);
 
 /* Compares the value of two hash elements A and B, given
  * auxiliary data AUX.  Returns true if A is less than B, or
  * false if A is greater than or equal to B. */
+/* 보조 데이터 AUX가 주어졌을 때, 두 해시 요소 A와 B의 값을 비교합니다.
+ * A가 B보다 작으면 true를 반환하고, A가 B보다 크거나 같으면 false를 반환합니다. */
 typedef bool hash_less_func (const struct hash_elem *a,
-		const struct hash_elem *b,
-		void *aux);
+       const struct hash_elem *b,
+       void *aux);
 
 /* Performs some operation on hash element E, given auxiliary
  * data AUX. */
+// 보조 데이터 AUX가 주어졌을 때, 해시 요소 E에 대해 어떤 작업을 수행합니다.
 typedef void hash_action_func (struct hash_elem *e, void *aux);
 
 /* Hash table. */
+// 해시 테이블.
 struct hash {
-	size_t elem_cnt;            /* Number of elements in table. */
-	size_t bucket_cnt;          /* Number of buckets, a power of 2. */
-	struct list *buckets;       /* Array of `bucket_cnt' lists. */
-	hash_hash_func *hash;       /* Hash function. */
-	hash_less_func *less;       /* Comparison function. */
-	void *aux;                  /* Auxiliary data for `hash' and `less'. */
+    size_t elem_cnt;            /* Number of elements in table. */
+                                // 테이블 내 요소의 수.
+    size_t bucket_cnt;          /* Number of buckets, a power of 2. */
+                                // 버킷의 수, 2의 거듭제곱.
+    struct list *buckets;       /* Array of `bucket_cnt' lists. */
+                                // `bucket_cnt` 개수만큼의 리스트 배열.
+    hash_hash_func *hash;       /* Hash function. */
+                                // 해시 함수.
+    hash_less_func *less;       /* Comparison function. */
+                                // 비교 함수.
+    void *aux;                  /* Auxiliary data for `hash' and `less'. */
+                                // `hash`와 `less`를 위한 보조 데이터.
 };
 
 /* A hash table iterator. */
+// 해시 테이블 반복자.
 struct hash_iterator {
-	struct hash *hash;          /* The hash table. */
-	struct list *bucket;        /* Current bucket. */
-	struct hash_elem *elem;     /* Current hash element in current bucket. */
+    struct hash *hash;          /* The hash table. */
+                                // 해시 테이블.
+    struct list *bucket;        /* Current bucket. */
+                                // 현재 버킷.
+    struct hash_elem *elem;     /* Current hash element in current bucket. */
+                                // 현재 버킷 내의 현재 해시 요소.
 };
 
 /* Basic life cycle. */
+// 기본 생명 주기.
 bool hash_init (struct hash *, hash_hash_func *, hash_less_func *, void *aux);
 void hash_clear (struct hash *, hash_action_func *);
 void hash_destroy (struct hash *, hash_action_func *);
 
 /* Search, insertion, deletion. */
+// 검색, 삽입, 삭제.
 struct hash_elem *hash_insert (struct hash *, struct hash_elem *);
 struct hash_elem *hash_replace (struct hash *, struct hash_elem *);
 struct hash_elem *hash_find (struct hash *, struct hash_elem *);
 struct hash_elem *hash_delete (struct hash *, struct hash_elem *);
 
 /* Iteration. */
+// 반복.
 void hash_apply (struct hash *, hash_action_func *);
 void hash_first (struct hash_iterator *, struct hash *);
 struct hash_elem *hash_next (struct hash_iterator *);
 struct hash_elem *hash_cur (struct hash_iterator *);
 
 /* Information. */
+// 정보.
 size_t hash_size (struct hash *);
 bool hash_empty (struct hash *);
 
 /* Sample hash functions. */
+// 샘플 해시 함수.
 uint64_t hash_bytes (const void *, size_t);
 uint64_t hash_string (const char *);
 uint64_t hash_int (int);
 
 #endif /* lib/kernel/hash.h */
+// lib/kernel/hash.h

--- a/include/vm/uninit.h
+++ b/include/vm/uninit.h
@@ -9,12 +9,14 @@ typedef bool vm_initializer (struct page *, void *aux);
 
 /* Uninitlialized page. The type for implementing the
  * "Lazy loading". */
+/* 초기화되지 않은 페이지. "지연 로딩(lazy loading)"을 구현하기 위한 타입 */
 struct uninit_page {
-	/* Initiate the contets of the page */
+	/* Initiate the contets of the page, 페이지의 내용을 초기화 */
 	vm_initializer *init;
 	enum vm_type type;
 	void *aux;
-	/* Initiate the struct page and maps the pa to the va */
+	/* Initiate the struct page and maps the pa to the va.
+	 * struct page를 초기화하고 물리 주소(pa)를 가상 주소(va)에 매핑*/
 	bool (*page_initializer) (struct page *, enum vm_type, void *kva);
 };
 

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -1,22 +1,30 @@
 #ifndef VM_VM_H
 #define VM_VM_H
 #include <stdbool.h>
+#include "hash.h"
 #include "threads/palloc.h"
 
 enum vm_type {
 	/* page not initialized */
+	/* 페이지가 초기화 되지 않음 */
 	VM_UNINIT = 0,
 	/* page not related to the file, aka anonymous page */
+	/* 파일과 관련 없는 페이지. 즉, 익명 페이지 */
 	VM_ANON = 1,
 	/* page that realated to the file */
+	/* 파일과 관련된 페이지 */
 	VM_FILE = 2,
 	/* page that hold the page cache, for project 4 */
+	/* 페이지 캐시를 보유하는 페이지(프로젝트 4) */
 	VM_PAGE_CACHE = 3,
 
 	/* Bit flags to store state */
+	/* 상태를 저장하기 위한 비트 플래그 */
 
 	/* Auxillary bit flag marker for store information. You can add more
 	 * markers, until the value is fit in the int. */
+	/* 정보 저장을 위한 보조 비트 플래그 마커.
+	 * int 값에 맞을 때 까지 더 많은 마커를 추가할 수 있음 */
 	VM_MARKER_0 = (1 << 3),
 	VM_MARKER_1 = (1 << 4),
 
@@ -40,15 +48,23 @@ struct thread;
  * This is kind of "parent class", which has four "child class"es, which are
  * uninit_page, file_page, anon_page, and page cache (project4).
  * DO NOT REMOVE/MODIFY PREDEFINED MEMBER OF THIS STRUCTURE. */
+/* page의 표현
+ * 이는 일종의 "부모 클래스"이며, uninit_page, file_page, anon_page,
+ * 그리고 페이지 캐시(프로젝트 4)라는 4 개의 "자식 클래스"를 가짐
+ * 이 구조체의 미리 정의된 멤버를 제거하거나 수정하지 말것 */
 struct page {
 	const struct page_operations *operations;
-	void *va;              /* Address in terms of user space */
-	struct frame *frame;   /* Back reference for frame */
+	void *va;              /* Address in terms of user space, 사용자 공간 관점에서의 주소 */
+	struct frame *frame;   /* Back reference for frame, 프레임에 대한 역참조 */
 
 	/* Your implementation */
+	/* 아래 구현 */
+	struct hash_elem hash_elem; // SPT 삽입용 elem
 
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
+	/* 타입별 데이터는 공용체(union)에 바인딩됨
+	 * 각 함수는 현재 union을 자동으로 감지 */
 	union {
 		struct uninit_page uninit;
 		struct anon_page anon;
@@ -60,6 +76,7 @@ struct page {
 };
 
 /* The representation of "frame" */
+/* frame의 표현 */
 struct frame {
 	void *kva;
 	struct page *page;
@@ -69,6 +86,10 @@ struct frame {
  * This is one way of implementing "interface" in C.
  * Put the table of "method" into the struct's member, and
  * call it whenever you needed. */
+/* 페이지 연산을 위한 함수 테이블
+ * 이는 C에서 "인터페이스"를 구현하는 한 가지 방법임
+ * "메서드" 테이블을 구조체에 넣고,
+ * 필요할 때마다 호출 */
 struct page_operations {
 	bool (*swap_in) (struct page *, void *);
 	bool (*swap_out) (struct page *);
@@ -84,7 +105,11 @@ struct page_operations {
 /* Representation of current process's memory space.
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
+/* 현재 프로세스의 메모리 공간 표현
+ * 이 구조체에 대해 특정 디자인을 따르도록 강요하지 않는다.
+ * 모든 디자인은 너에게 달려있다 */
 struct supplemental_page_table {
+	struct hash spt_hash; // 해당 프로세스가 관리하는 전체 페이지 정보를 담는 해시 테이블
 };
 
 #include "threads/thread.h"

--- a/tests/vm/child-inherit.c
+++ b/tests/vm/child-inherit.c
@@ -1,16 +1,24 @@
 /* Child process for mmap-inherit test.
-   Tries to write to a mapping present in the parent.
+Tries to write to a mapping present in the parent.
    The process must be terminated with -1 exit code. */
+// mmap-inherit 테스트를 위한 자식 프로세스입니다.
+// 부모에 있는 매핑에 쓰기를 시도합니다.
+// 프로세스는 -1 종료 코드로 종료되어야 합니다.
 
-#include <string.h>
-#include "tests/vm/sample.inc"
-#include "tests/lib.h"
-#include "tests/main.h"
+#include <string.h>             // memset 함수를 사용하기 위해 포함합니다.
+#include "tests/vm/sample.inc" // 테스트에 사용될 샘플 데이터를 포함합니다. (sample 배열 등)
+#include "tests/lib.h"         // Pintos 테스트 라이브러리를 포함합니다. (fail, CHECK 등)
+#include "tests/main.h"        // Pintos 테스트 프레임워크의 메인 부분을 포함합니다. (test_main 등)
 
 void
-test_main (void)
+test_main (void)                // 테스트의 메인 함수입니다.
 {
-  memset ((char *) 0x54321000, 0, 4096);
-  fail ("child can modify parent's memory mappings");
-}
+    // 0x54321000 주소부터 4096 바이트(한 페이지)를 0으로 채우려고 시도합니다.
+    // 이 주소는 부모 프로세스로부터 상속받은 메모리 매핑 영역이어야 하며,
+    // 자식 프로세스가 이 영역에 쓰기를 시도할 때 접근 권한 등에 의해 실패해야 합니다.
+    memset ((char *) 0x54321000, 0, 4096);
 
+    // 만약 위의 memset 작업이 성공했다면 (즉, 자식 프로세스가 부모의 메모리 매핑을 수정할 수 있다면),
+    // 테스트는 실패한 것입니다. 이 경우 fail 함수를 호출하여 테스트 실패를 알립니다.
+    fail ("child can modify parent's memory mappings");
+}

--- a/tests/vm/child-linear.c
+++ b/tests/vm/child-linear.c
@@ -1,36 +1,42 @@
 /* Child process of page-parallel.
-   Encrypts 1 MB of zeros, then decrypts it, and ensures that
+Encrypts 1 MB of zeros, then decrypts it, and ensures that
    the zeros are back. */
+// page-parallel 테스트의 자식 프로세스입니다.
+// 1MB 크기의 0으로 채워진 데이터를 암호화한 후 복호화하여,
+// 다시 0으로 돌아왔는지 확인합니다.
 
-#include <string.h>
-#include "tests/arc4.h"
-#include "tests/lib.h"
-#include "tests/main.h"
+#include <string.h>        // strlen 함수를 사용하기 위해 포함합니다.
+#include "tests/arc4.h"    // ARC4 암호화 알고리즘 관련 함수를 사용하기 위해 포함합니다.
+#include "tests/lib.h"     // Pintos 테스트 라이브러리를 포함합니다. (fail 등)
+#include "tests/main.h"    // 테스트 프레임워크의 메인 부분을 포함합니다.
 
-const char *test_name = "child-linear";
+const char *test_name = "child-linear"; // 테스트의 이름을 정의합니다.
 
-#define SIZE (1024 * 1024)
-static char buf[SIZE];
+#define SIZE (1024 * 1024) // 버퍼의 크기를 1MB로 정의합니다.
+static char buf[SIZE];     // 1MB 크기의 정적 버퍼를 선언합니다.
 
 int
-main (int argc, char *argv[])
+main (int argc, char *argv[]) // 프로그램의 주 진입점입니다.
 {
-  const char *key = argv[argc - 1];
-  struct arc4 arc4;
-  size_t i;
+    const char *key = argv[argc - 1]; // 명령행 인자의 마지막 값을 암호화 키로 사용합니다.
+    struct arc4 arc4;                 // ARC4 암호화 상태를 저장할 구조체입니다.
+    size_t i;                         // 반복문에서 사용할 인덱스 변수입니다.
 
-  /* Encrypt zeros. */
-  arc4_init (&arc4, key, strlen (key));
-  arc4_crypt (&arc4, buf, SIZE);
+    /* Encrypt zeros. */
+    // 0으로 채워진 데이터를 암호화합니다.
+    arc4_init (&arc4, key, strlen (key)); // ARC4 구조체를 주어진 키로 초기화합니다.
+    arc4_crypt (&arc4, buf, SIZE);        // buf의 내용을 SIZE만큼 암호화합니다. (초기 buf는 전역변수이므로 0으로 초기화됨)
 
-  /* Decrypt back to zeros. */
-  arc4_init (&arc4, key, strlen (key));
-  arc4_crypt (&arc4, buf, SIZE);
+    /* Decrypt back to zeros. */
+    // 다시 0으로 복호화합니다.
+    arc4_init (&arc4, key, strlen (key)); // ARC4 구조체를 동일한 키로 다시 초기화합니다. (암호화와 동일한 상태에서 시작)
+    arc4_crypt (&arc4, buf, SIZE);        // 암호화된 buf의 내용을 SIZE만큼 복호화합니다.
 
-  /* Check that it's all zeros. */
-  for (i = 0; i < SIZE; i++)
-    if (buf[i] != '\0')
-      fail ("byte %zu != 0", i);
+    /* Check that it's all zeros. */
+    // 모든 내용이 0인지 확인합니다.
+    for (i = 0; i < SIZE; i++)          // 버퍼의 모든 바이트를 순회합니다.
+        if (buf[i] != '\0')             // 만약 해당 바이트가 0이 아니면,
+            fail ("byte %zu != 0", i);    // 테스트 실패를 알립니다.
 
-  return 0x42;
+    return 0x42; // 성공 시 특정 값(0x42)을 반환합니다.
 }

--- a/tests/vm/child-mm-wrt.c
+++ b/tests/vm/child-mm-wrt.c
@@ -2,23 +2,32 @@
    Mmaps a file and writes to it via the mmap'ing, then exits
    without calling munmap.  The data in the mapped region must be
    written out at program termination. */
+// mmap-exit 테스트의 자식 프로세스입니다.
+// 파일을 메모리 맵하고, 메모리 맵을 통해 파일에 쓴 다음,
+// munmap을 호출하지 않고 종료합니다. 맵된 영역의 데이터는
+// 프로그램 종료 시 파일에 기록되어야 합니다.
 
-#include <string.h>
-#include <syscall.h>
-#include "tests/vm/sample.inc"
-#include "tests/lib.h"
-#include "tests/main.h"
+#include <string.h>             // memcpy 함수를 사용하기 위해 포함합니다.
+#include <syscall.h>            // Pintos 시스템 콜(create, open, mmap 등)을 사용하기 위해 포함합니다.
+#include "tests/vm/sample.inc" // 테스트에 사용될 샘플 데이터(sample 배열)를 포함합니다.
+#include "tests/lib.h"         // Pintos 테스트 라이브러리(CHECK, MAP_FAILED 등)를 포함합니다.
+#include "tests/main.h"        // 테스트 프레임워크의 메인 부분을 포함합니다.
 
-#define ACTUAL ((void *) 0x10000000)
+#define ACTUAL ((void *) 0x10000000) // 메모리 매핑을 위한 가상 주소입니다.
 
 void
-test_main (void)
+test_main (void)                    // 테스트의 메인 함수입니다.
 {
-  int handle;
+    int handle;                       // 파일 핸들(디스크립터)을 저장할 변수입니다.
 
-  CHECK (create ("sample.txt", sizeof sample), "create \"sample.txt\"");
-  CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
-  CHECK (mmap (ACTUAL, sizeof sample, 1, handle, 0) != MAP_FAILED, "mmap \"sample.txt\"");
-  memcpy (ACTUAL, sample, sizeof sample);
+    // "sample.txt"라는 이름으로 sample 데이터 크기만큼의 파일을 생성합니다. 성공 여부를 CHECK 합니다.
+    CHECK (create ("sample.txt", sizeof sample), "create \"sample.txt\"");
+    // "sample.txt" 파일을 엽니다. 파일 핸들이 1보다 큰지 (유효한지) CHECK 합니다.
+    CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+    // "sample.txt" 파일을 ACTUAL 주소에 sample 크기만큼 메모리 매핑합니다. PROT_WRITE (1) 권한을 부여합니다.
+    // 매핑 실패 여부를 CHECK 합니다.
+    CHECK (mmap (ACTUAL, sizeof sample, 1, handle, 0) != MAP_FAILED, "mmap \"sample.txt\"");
+    // sample 데이터를 메모리 매핑된 영역(ACTUAL)으로 복사합니다.
+    memcpy (ACTUAL, sample, sizeof sample);
+    // munmap을 호출하지 않고 함수가 종료됩니다. 이 때 ACTUAL에 쓰여진 내용이 파일에 반영되어야 합니다.
 }
-

--- a/tests/vm/child-qsort-mm.c
+++ b/tests/vm/child-qsort-mm.c
@@ -1,25 +1,33 @@
 /* Mmaps a 128 kB file "sorts" the bytes in it, using quick sort,
    a multi-pass divide and conquer algorithm.  */
+// 128KB 파일을 메모리 맵하고 그 안의 바이트들을
+// 퀵 정렬(다중 패스 분할 정복 알고리즘)을 사용하여 "정렬"합니다.
 
-#include <debug.h>
-#include <syscall.h>
-#include "tests/lib.h"
-#include "tests/main.h"
-#include "tests/vm/qsort.h"
+#include <debug.h>      // DEBUG 매크로 등을 사용하기 위해 포함합니다 (여기선 직접 사용 안됨).
+#include <syscall.h>    // Pintos 시스템 콜(open, mmap 등)을 사용하기 위해 포함합니다.
+#include "tests/lib.h"  // Pintos 테스트 라이브러리(CHECK, quiet, MAP_FAILED 등)를 포함합니다.
+#include "tests/main.h" // 테스트 프레임워크의 메인 부분을 포함합니다.
+#include "tests/vm/qsort.h" // qsort_bytes 함수를 사용하기 위해 포함합니다.
 
-const char *test_name = "child-qsort-mm";
+const char *test_name = "child-qsort-mm"; // 테스트의 이름을 정의합니다.
 
 int
-main (int argc UNUSED, char *argv[]) 
+main (int argc UNUSED, char *argv[]) // 프로그램의 주 진입점입니다. argc는 사용되지 않음을 표시합니다.
 {
-  int handle;
-  unsigned char *p = (unsigned char *) 0x10000000;
+    int handle;                        // 파일 핸들을 저장할 변수입니다.
+    // 메모리 매핑을 위한 타겟 가상 주소입니다. (0x10000000)
+    unsigned char *p = (unsigned char *) 0x10000000;
 
-  quiet = true;
+    quiet = true;                      // 테스트 라이브러리의 상세 메시지 출력을 억제합니다.
 
-  CHECK ((handle = open (argv[1])) > 1, "open \"%s\"", argv[1]);
-  CHECK (mmap (p, 4096*33, 1, handle, 0) != MAP_FAILED, "mmap \"%s\"", argv[1]);
-  qsort_bytes (p, 1024 * 128);
-  
-  return 80;
+    // 명령행 인자로 받은 파일(argv[1])을 엽니다. 성공 여부를 CHECK 합니다.
+    CHECK ((handle = open (argv[1])) > 1, "open \"%s\"", argv[1]);
+    // 파일을 p 주소에 4096*33 (132KB) 바이트 크기만큼, 쓰기 가능(1)으로 메모리 매핑합니다.
+    // 매핑 실패 여부를 CHECK 합니다.
+    CHECK (mmap (p, 4096*33, 1, handle, 0) != MAP_FAILED, "mmap \"%s\"", argv[1]);
+    // 메모리 매핑된 영역(p)의 데이터를 128KB (1024*128) 만큼 바이트 단위로 퀵 정렬합니다.
+    qsort_bytes (p, 1024 * 128);
+
+    // munmap이나 close 없이 종료될 수 있습니다 (테스트 시나리오에 따라).
+    return 80; // 성공 시 특정 값(80)을 반환합니다.
 }

--- a/tests/vm/child-qsort.c
+++ b/tests/vm/child-qsort.c
@@ -1,32 +1,33 @@
-/* Reads a 128 kB file onto the stack and "sorts" the bytes in
-   it, using quick sort, a multi-pass divide and conquer
-   algorithm.  The sorted data is written back to the same file
-   in-place. */
+/* Child process of mmap-exit.
+   Mmaps a file and writes to it via the mmap'ing, then exits
+   without calling munmap.  The data in the mapped region must be
+   written out at program termination. */
+// mmap-exit 테스트의 자식 프로세스입니다.
+// 파일을 메모리 맵하고, 메모리 맵을 통해 파일에 쓴 다음,
+// munmap을 호출하지 않고 종료합니다. 맵된 영역의 데이터는
+// 프로그램 종료 시 파일에 기록되어야 합니다.
 
-#include <debug.h>
-#include <syscall.h>
-#include "tests/lib.h"
-#include "tests/main.h"
-#include "tests/vm/qsort.h"
+#include <string.h>             // memcpy 함수를 사용하기 위해 포함합니다.
+#include <syscall.h>            // Pintos 시스템 콜(create, open, mmap 등)을 사용하기 위해 포함합니다.
+#include "tests/vm/sample.inc" // 테스트에 사용될 샘플 데이터(sample 배열)를 포함합니다.
+#include "tests/lib.h"         // Pintos 테스트 라이브러리(CHECK, MAP_FAILED 등)를 포함합니다.
+#include "tests/main.h"        // 테스트 프레임워크의 메인 부분을 포함합니다.
 
-const char *test_name = "child-qsort";
+#define ACTUAL ((void *) 0x10000000) // 메모리 매핑을 위한 가상 주소입니다.
 
-int
-main (int argc UNUSED, char *argv[]) 
+void
+test_main (void)                    // 테스트의 메인 함수입니다.
 {
-  int handle;
-  unsigned char buf[128 * 1024];
-  size_t size;
+  int handle;                       // 파일 핸들(디스크립터)을 저장할 변수입니다.
 
-  quiet = true;
-
-  CHECK ((handle = open (argv[1])) > 1, "open \"%s\"", argv[1]);
-
-  size = read (handle, buf, sizeof buf);
-  qsort_bytes (buf, sizeof buf);
-  seek (handle, 0);
-  write (handle, buf, size);
-  close (handle);
-  
-  return 72;
+  // "sample.txt"라는 이름으로 sample 데이터 크기만큼의 파일을 생성합니다. 성공 여부를 CHECK 합니다.
+  CHECK (create ("sample.txt", sizeof sample), "create \"sample.txt\"");
+  // "sample.txt" 파일을 엽니다. 파일 핸들이 1보다 큰지 (유효한지) CHECK 합니다.
+  CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // "sample.txt" 파일을 ACTUAL 주소에 sample 크기만큼 메모리 매핑합니다. PROT_WRITE (1) 권한을 부여합니다.
+  // 매핑 실패 여부를 CHECK 합니다.
+  CHECK (mmap (ACTUAL, sizeof sample, 1, handle, 0) != MAP_FAILED, "mmap \"sample.txt\"");
+  // sample 데이터를 메모리 매핑된 영역(ACTUAL)으로 복사합니다.
+  memcpy (ACTUAL, sample, sizeof sample);
+  // munmap을 호출하지 않고 함수가 종료됩니다. 이 때 ACTUAL에 쓰여진 내용이 파일에 반영되어야 합니다.
 }

--- a/tests/vm/child-sort.c
+++ b/tests/vm/child-sort.c
@@ -1,42 +1,54 @@
 /* Reads a 128 kB file into static data and "sorts" the bytes in
    it, using counting sort, a single-pass algorithm.  The sorted
    data is written back to the same file in-place. */
+// 128KB 파일을 정적 데이터로 읽어들여 그 안의 바이트들을
+// 계수 정렬(단일 패스 알고리즘)을 사용하여 "정렬"합니다.
+// 정렬된 데이터는 동일한 파일에 원래 위치에 다시 쓰여집니다.
 
-#include <debug.h>
-#include <syscall.h>
-#include "tests/lib.h"
-#include "tests/main.h"
+#include <debug.h>      // DEBUG 매크로 등을 사용하기 위해 포함합니다 (여기선 직접 사용 안됨).
+#include <syscall.h>    // Pintos 시스템 콜(open, read, write, seek, close 등)을 사용하기 위해 포함합니다.
+#include "tests/lib.h"  // Pintos 테스트 라이브러리(CHECK, quiet 등)를 포함합니다.
+#include "tests/main.h" // 테스트 프레임워크의 메인 부분을 포함합니다.
 
-const char *test_name = "child-sort";
+const char *test_name = "child-sort"; // 테스트의 이름을 정의합니다.
 
-unsigned char buf[128 * 1024];
-size_t histogram[256];
+unsigned char buf[128 * 1024];     // 128KB 크기의 정적 데이터 버퍼입니다.
+size_t histogram[256];             // 각 바이트 값(0-255)의 빈도수를 저장할 히스토그램 배열입니다.
 
 int
-main (int argc UNUSED, char *argv[]) 
+main (int argc UNUSED, char *argv[]) // 프로그램의 주 진입점입니다. argc는 사용되지 않음을 표시합니다.
 {
-  int handle;
-  unsigned char *p;
-  size_t size;
-  size_t i;
+  int handle;                        // 파일 핸들을 저장할 변수입니다.
+  unsigned char *p;                  // 버퍼를 순회하며 정렬된 값을 채워넣을 포인터입니다.
+  size_t size;                       // 파일에서 읽은 실제 데이터의 크기를 저장할 변수입니다.
+  size_t i;                          // 반복문에서 사용할 인덱스 변수입니다.
 
-  quiet = true;
+  quiet = true;                      // 테스트 라이브러리의 상세 메시지 출력을 억제합니다.
 
+  // 명령행 인자로 받은 파일(argv[1])을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open (argv[1])) > 1, "open \"%s\"", argv[1]);
 
+  // 파일로부터 buf 크기만큼 데이터를 읽어들입니다. 실제 읽은 크기를 size에 저장합니다.
   size = read (handle, buf, sizeof buf);
+  // 읽어들인 데이터(buf)의 각 바이트 값에 해당하는 히스토그램 인덱스의 값을 1 증가시킵니다.
   for (i = 0; i < size; i++)
     histogram[buf[i]]++;
-  p = buf;
-  for (i = 0; i < sizeof histogram / sizeof *histogram; i++) 
+
+  p = buf; // 포인터 p를 버퍼의 시작으로 설정합니다.
+  // 히스토그램 배열을 순회합니다 (0부터 255까지의 바이트 값).
+  for (i = 0; i < sizeof histogram / sizeof *histogram; i++)
     {
-      size_t j = histogram[i];
+      size_t j = histogram[i]; // 현재 바이트 값(i)의 빈도수를 j에 저장합니다.
+      // 해당 바이트 값(i)을 빈도수(j)만큼 버퍼 p에 순차적으로 기록합니다.
       while (j-- > 0)
         *p++ = i;
     }
+  // 파일 포인터를 파일의 시작으로 이동합니다.
   seek (handle, 0);
+  // 정렬된 데이터(buf)를 파일에 씁니다. (실제 읽었던 size 만큼)
   write (handle, buf, size);
+  // 파일을 닫습니다.
   close (handle);
-  
-  return 123;
+
+  return 123; // 성공 시 특정 값(123)을 반환합니다.
 }

--- a/tests/vm/child-swap.c
+++ b/tests/vm/child-swap.c
@@ -1,39 +1,44 @@
 /* Each thread will read 5MB of anonymous pages
- * Lastly, frees the allocated memory. 
+ * Lastly, frees the allocated memory.
  */
+// 각 스레드는 5MB의 익명 페이지를 읽을 것입니다. (주석은 스레드를 언급하지만, 이 코드는 단일 test_main)
+// 마지막으로 할당된 메모리를 해제합니다. (이 코드에서는 명시적 해제보다는 exit에 의한 OS 정리를 의미하는 듯)
 
-#include <string.h>
-#include <stdint.h>
-#include <syscall.h>
-#include "tests/lib.h"
-#include "tests/main.h"
+#include <string.h>  // 문자열 함수 (여기서는 직접 사용되지 않음)
+#include <stdint.h>  // 정수형 타입 (size_t 등)
+#include <syscall.h> // Pintos 시스템 콜 (exit, fail 등)
+#include "tests/lib.h"  // Pintos 테스트 라이브러리 (fail 등)
+#include "tests/main.h" // 테스트 프레임워크의 메인 부분을 포함합니다.
 
 
-#define PAGE_SHIFT 12
-#define PAGE_SIZE (1 << PAGE_SHIFT) // 4KB
-#define ONE_MB (1 << 20) // 1MB
-#define CHUNK_SIZE (1*ONE_MB)
-#define PAGE_COUNT (CHUNK_SIZE / PAGE_SIZE)
+#define PAGE_SHIFT 12                // 페이지 크기를 위한 시프트 값 (2^12 = 4096)
+#define PAGE_SIZE (1 << PAGE_SHIFT)  // 페이지 크기 (4KB)
+#define ONE_MB (1 << 20)             // 1MB 크기
+#define CHUNK_SIZE (1*ONE_MB)        // 테스트에서 사용할 메모리 청크 크기 (1MB)
+#define PAGE_COUNT (CHUNK_SIZE / PAGE_SIZE) // 청크 내 페이지 수 (1MB / 4KB = 256 페이지)
 
-static char big_chunks[CHUNK_SIZE];
+static char big_chunks[CHUNK_SIZE]; // 1MB 크기의 정적 데이터 배열입니다. 익명 페이지로 취급될 것입니다.
 
 void
-test_main (void) 
+test_main (void)                    // 테스트의 메인 함수입니다.
 {
-	size_t i;
-    char *mem;
+    size_t i;                         // 반복문 인덱스 변수입니다.
+    char *mem;                        // 메모리 특정 위치를 가리킬 포인터입니다.
 
+    // CHUNK_SIZE (1MB) 만큼의 메모리 영역을 페이지 단위로 순회하며 값을 씁니다.
+    // 이 과정에서 페이지 폴트가 발생하고, 물리 메모리가 할당되며, 필요시 스왑 아웃될 수 있습니다.
     for (i = 0 ; i < PAGE_COUNT ; i++) {
-        mem = (big_chunks+(i*PAGE_SIZE));
-        *mem = (char)i;
+        mem = (big_chunks+(i*PAGE_SIZE)); // 현재 페이지의 시작 주소를 계산합니다.
+        *mem = (char)i;                   // 해당 페이지의 첫 바이트에 페이지 번호(i)를 저장합니다.
     }
 
+    // 다시 메모리 영역을 페이지 단위로 순회하며 값을 읽고 확인합니다.
+    // 이 과정에서 스왑 아웃된 페이지는 다시 스왑 인 되어야 합니다.
     for (i = 0 ; i < PAGE_COUNT ; i++) {
-        mem = (big_chunks+(i*PAGE_SIZE));
-        if((char)i != *mem) {
-		    fail ("data is inconsistent");
+        mem = (big_chunks+(i*PAGE_SIZE)); // 현재 페이지의 시작 주소를 계산합니다.
+        if((char)i != *mem) {             // 이전에 저장한 값과 현재 읽은 값이 다르면,
+            fail ("data is inconsistent");  // 데이터 불일치로 테스트 실패를 알립니다.
         }
     }
-    exit(0);
+    exit(0); // 모든 검사를 통과하면 성공적으로 종료합니다 (종료 코드 0).
 }
-

--- a/tests/vm/lazy-anon.c
+++ b/tests/vm/lazy-anon.c
@@ -1,4 +1,5 @@
 /* Checks if anonymous pages are lazy loaded  */
+// 익명 페이지가 지연 로딩되는지 확인합니다.
 
 #include <string.h>
 #include <syscall.h>
@@ -7,42 +8,45 @@
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define PAGE_SIZE 4096
-#define CHUNK_PAGE_COUNT 3
-#define CHUNK_SIZE (CHUNK_PAGE_COUNT * PAGE_SIZE)
+#define PAGE_SIZE 4096                             // 페이지 크기를 4096 바이트로 정의합니다.
+#define CHUNK_PAGE_COUNT 3                         // 테스트에 사용할 페이지의 개수를 정의합니다.
+#define CHUNK_SIZE (CHUNK_PAGE_COUNT * PAGE_SIZE)  // 전체 청크 크기를 계산합니다 (3 * 4KB = 12KB).
 
-static char buf[CHUNK_SIZE];
+static char buf[CHUNK_SIZE]; // 익명 페이지로 사용될 정적 버퍼를 선언합니다.
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-	size_t i, j;
-	void *pa;
+	size_t i, j;   // 반복문에서 사용할 인덱스 변수입니다.
+	void *pa;      // 물리 주소를 저장할 포인터입니다.
 
-	msg ("initial pages status");
-	for (i = 0 ; i < CHUNK_PAGE_COUNT ; i++) {
+	msg ("initial pages status"); // 초기 페이지 상태 메시지를 출력합니다.
+	for (i = 0 ; i < CHUNK_PAGE_COUNT ; i++) { // 버퍼 내 각 페이지를 순회합니다.
 		// All pages for buf should not be loaded yet.
-		pa = get_phys_addr(&buf[i*PAGE_SIZE]);
-		CHECK (pa == 0, "check if page is not loaded");
+		// buf의 모든 페이지는 아직 로드되지 않았어야 합니다.
+		pa = get_phys_addr(&buf[i*PAGE_SIZE]);      // 현재 페이지의 시작 가상 주소에 대한 물리 주소를 가져옵니다.
+		CHECK (pa == 0, "check if page is not loaded"); // 물리 주소가 0인지 (즉, 아직 물리 메모리에 할당되지 않았는지) 확인합니다.
 	}
 
-	msg ("load pages");
-	for (i = 0 ; i < CHUNK_PAGE_COUNT ; i++) {
-		msg ("load page [%zu]", i);
+	msg ("load pages"); // 페이지 로드 시작 메시지를 출력합니다.
+	for (i = 0 ; i < CHUNK_PAGE_COUNT ; i++) { // 각 페이지를 순차적으로 접근하여 로드합니다.
+		msg ("load page [%zu]", i); // 현재 로드할 페이지 번호를 출력합니다.
 		// Pages are loaded here.
-		buf[i*PAGE_SIZE] = i;
-		for (j = 0 ; j < CHUNK_PAGE_COUNT ; j++) {
+		// 여기서 페이지가 로드됩니다.
+		buf[i*PAGE_SIZE] = i; // 현재 페이지의 첫 바이트에 페이지 번호(i)를 씁니다. 이 접근으로 인해 페이지 폴트가 발생하고 페이지가 로드됩니다.
+		for (j = 0 ; j < CHUNK_PAGE_COUNT ; j++) { // 모든 페이지의 상태를 다시 확인합니다.
 			// Pages that have been accessed should be loaded
+			// 접근된 페이지는 로드되어 있어야 합니다.
 			// Pages that have not been accessed should not be loaded.
-			pa = get_phys_addr(&buf[j*PAGE_SIZE]);
-			if (j <= i) {
-				CHECK (pa != 0, "check if page is loaded");
-				CHECK (buf[j*PAGE_SIZE] == (char) j, "check memory content");
+			// 접근되지 않은 페이지는 로드되지 않았어야 합니다.
+			pa = get_phys_addr(&buf[j*PAGE_SIZE]); // j번째 페이지의 물리 주소를 가져옵니다.
+			if (j <= i) { // 현재까지 접근한 페이지들(0부터 i번째 페이지까지)은
+				CHECK (pa != 0, "check if page is loaded"); // 물리 주소가 0이 아닌지(로드되었는지) 확인합니다.
+				CHECK (buf[j*PAGE_SIZE] == (char) j, "check memory content"); // 메모리 내용이 올바르게 쓰였는지 확인합니다.
 			}
-			else {
-				CHECK (pa == 0, "check if page is not loaded");
+			else { // 아직 접근하지 않은 페이지들은
+				CHECK (pa == 0, "check if page is not loaded"); // 물리 주소가 0인지(로드되지 않았는지) 확인합니다.
 			}
 		}
 	}
 }
-

--- a/tests/vm/lazy-file.c
+++ b/tests/vm/lazy-file.c
@@ -1,60 +1,71 @@
 /* Checks if file-mapped pages are lazy loaded  */
+// 파일 매핑된 페이지가 지연 로딩되는지 확인합니다.
 
-#include <string.h>
-#include <syscall.h>
-#include <stdio.h>
-#include <stdint.h>
-#include "tests/lib.h"
-#include "tests/main.h"
-#include "tests/vm/small.inc"
+#include <string.h>  // memcmp 함수를 사용하기 위해 포함합니다.
+#include <syscall.h> // Pintos 시스템 콜 (open, mmap, munmap, close, get_phys_addr 등)을 사용하기 위해 포함합니다.
+#include <stdio.h>   // msg 함수 (Pintos 테스트 라이브러리 내 구현)를 사용하기 위해 포함합니다.
+#include <stdint.h>  // 정수형 타입 (size_t 등)
+#include "tests/lib.h"  // Pintos 테스트 라이브러리 (CHECK, fail, msg, MAP_FAILED 등)를 포함합니다.
+#include "tests/main.h" // 테스트 프레임워크의 메인 부분을 포함합니다.
+#include "tests/vm/small.inc" // 테스트용 작은 데이터(small 배열)를 포함합니다.
 
-#define PAGE_SIZE 4096
-#define PAGE_SHIFT 12
+#define PAGE_SIZE 4096       // 페이지 크기를 4096 바이트로 정의합니다.
+#define PAGE_SHIFT 12        // 페이지 크기를 위한 시프트 값 (2^12 = 4096)
+// 주어진 크기 x를 페이지 크기의 배수로 올림하는 매크로입니다.
 #define PAGE_ALIGN_CEIL(x) ((x % PAGE_SIZE ? (x+PAGE_SIZE) : x) >> PAGE_SHIFT << PAGE_SHIFT)
 
 void
-test_main (void)
+test_main (void)             // 테스트의 메인 함수입니다.
 {
-	size_t handle;
-	size_t small_size;
-	char *actual = (char *) 0x10000000;
-	void *map;
-	size_t i, j;
-	size_t page_cnt;
-	void *pa;
+	size_t handle;             // 파일 핸들을 저장할 변수입니다.
+	size_t small_size;         // small 데이터의 크기를 저장할 변수입니다.
+	char *actual = (char *) 0x10000000; // 메모리 매핑을 위한 타겟 가상 주소입니다.
+	void *map;                 // mmap 호출의 반환 값(매핑된 주소)을 저장할 포인터입니다.
+	size_t i, j;               // 반복문에서 사용할 인덱스 변수입니다.
+	size_t page_cnt;           // 매핑된 파일의 페이지 수를 저장할 변수입니다.
+	void *pa;                  // 물리 주소를 저장할 포인터입니다.
 
 	/* Map pages to a file */
+	// 페이지를 파일에 매핑합니다.
+	// "small.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다. (small.txt는 small 데이터로 미리 만들어져 있어야 함)
 	CHECK ((handle = open ("small.txt")) > 1, "open \"small.txt\"");
-	small_size = sizeof small;
-	msg ("sizeof small: %zu", small_size);
-	msg ("page aligned size of small: %zu", PAGE_ALIGN_CEIL(small_size));
+	small_size = sizeof small; // small 데이터의 크기를 가져옵니다.
+	msg ("sizeof small: %zu", small_size); // small 데이터의 크기를 출력합니다.
+	msg ("page aligned size of small: %zu", PAGE_ALIGN_CEIL(small_size)); // 페이지 정렬된 small 데이터 크기를 출력합니다.
+	// actual 주소에 small 파일을 페이지 정렬된 크기만큼, 읽기 전용(세 번째 인자 0)으로 메모리 매핑합니다.
+	// 매핑 실패 여부를 CHECK 합니다.
 	CHECK ((map = mmap (actual, PAGE_ALIGN_CEIL(small_size), 0, handle, 0)) != MAP_FAILED, "mmap \"small.txt\"");
-	page_cnt = PAGE_ALIGN_CEIL(small_size) / PAGE_SIZE;
+	page_cnt = PAGE_ALIGN_CEIL(small_size) / PAGE_SIZE; // 매핑된 영역의 페이지 수를 계산합니다.
 
-	msg ("initial pages status");
-	for (i = 0 ; i < page_cnt ; i++) {
+	msg ("initial pages status"); // 초기 페이지 상태 메시지를 출력합니다.
+	for (i = 0 ; i < page_cnt ; i++) { // 모든 매핑된 페이지를 순회합니다.
 		// All pages for the file should not be loaded yet.
-		pa = get_phys_addr(&actual[i*PAGE_SIZE]);
-		CHECK (pa == 0, "check if page is not loaded");
+		// 파일에 대한 모든 페이지는 아직 로드되지 않았어야 합니다.
+		pa = get_phys_addr(&actual[i*PAGE_SIZE]); // 현재 페이지의 물리 주소를 가져옵니다.
+		CHECK (pa == 0, "check if page is not loaded"); // 물리 주소가 0인지(즉, 아직 로드되지 않았는지) 확인합니다.
 	}
-	msg ("load pages (%zu)", page_cnt);
-	for (i = 0 ; i < page_cnt ; i++) {
-		msg ("load page [%zu]", i);
+	msg ("load pages (%zu)", page_cnt); // 페이지 로드 시작 메시지를 출력합니다.
+	for (i = 0 ; i < page_cnt ; i++) { // 모든 페이지를 순차적으로 접근하여 로드합니다.
+		msg ("load page [%zu]", i); // 현재 로드할 페이지 번호를 출력합니다.
+		// 현재 페이지(actual + i*PAGE_SIZE)의 내용 10바이트를 원본 small 데이터와 비교합니다.
+		// 이 접근으로 인해 해당 페이지가 메모리에 로드(페이지 폴트 처리)되어야 합니다.
 		if (memcmp (actual+i*PAGE_SIZE, small+i*PAGE_SIZE, 10))
-			fail ("read of mmap'd file reported bad data");
-		for (j = 0 ; j < page_cnt ; j++) {
-			pa = get_phys_addr(&actual[j*PAGE_SIZE]);
-			if (j <= i) {
+			fail ("read of mmap'd file reported bad data"); // 데이터가 다르면 테스트 실패를 알립니다.
+
+		for (j = 0 ; j < page_cnt ; j++) { // 모든 페이지의 상태를 다시 확인합니다.
+			pa = get_phys_addr(&actual[j*PAGE_SIZE]); // j번째 페이지의 물리 주소를 가져옵니다.
+			if (j <= i) { // 현재까지 접근한 페이지들(0부터 i번째 페이지까지)은
 				// Pages that have been accessed should be loaded
-				CHECK (pa != 0, "check if page is loaded");
+				// 접근된 페이지는 로드되어 있어야 합니다.
+				CHECK (pa != 0, "check if page is loaded"); // 물리 주소가 0이 아닌지(로드되었는지) 확인합니다.
 			}
-			else {
+			else { // 아직 접근하지 않은 페이지들은
 				// Pages that have not been accessed should not be loaded.
-				CHECK (pa == 0, "check if page is not loaded");
+				// 접근되지 않은 페이지는 로드되지 않았어야 합니다.
+				CHECK (pa == 0, "check if page is not loaded"); // 물리 주소가 0인지(로드되지 않았는지) 확인합니다.
 			}
 		}
 	}
-	munmap (map);
-	close (handle);
+	munmap (map); // 메모리 매핑을 해제합니다.
+	close (handle); // 파일을 닫습니다.
 }
-

--- a/tests/vm/mmap-bad-fd.c
+++ b/tests/vm/mmap-bad-fd.c
@@ -1,15 +1,19 @@
 /* Tries to mmap an invalid fd,
-   which must either fail silently or terminate the process with
+which must either fail silently or terminate the process with
    exit code -1. */
+// 유효하지 않은 fd로 mmap을 시도합니다.
+// 이는 조용히 실패하거나 프로세스를 -1 종료 코드로
+// 종료해야 합니다.
 
-#include <syscall.h>
-#include "tests/lib.h"
-#include "tests/main.h"
+#include <syscall.h>    // Pintos 시스템 콜 (mmap, CHECK, MAP_FAILED 등)을 사용하기 위해 포함합니다.
+#include "tests/lib.h"  // Pintos 테스트 라이브러리를 포함합니다.
+#include "tests/main.h" // 테스트 프레임워크의 메인 부분을 포함합니다.
 
 void
-test_main (void) 
+test_main (void)        // 테스트의 메인 함수입니다.
 {
-  CHECK (mmap ((void *) 0x10000000, 4096, 0, 0x5678, 0) == MAP_FAILED,
-         "try to mmap invalid fd");
+    // 가상 주소 0x10000000에 4096 바이트 크기로 유효하지 않은 fd (0x5678)를 mmap 시도합니다.
+    // 이 호출은 MAP_FAILED를 반환해야 합니다. 성공 여부를 CHECK 합니다.
+    CHECK (mmap ((void *) 0x10000000, 4096, 0, 0x5678, 0) == MAP_FAILED,
+           "try to mmap invalid fd");
 }
-

--- a/tests/vm/mmap-bad-fd2.c
+++ b/tests/vm/mmap-bad-fd2.c
@@ -1,16 +1,20 @@
 /* Tries to mmap with fd 0,
-   which is the file descriptor for console input. 
-	 mmap must fail silently or terminate the process with  
+which is the file descriptor for console input.
+     mmap must fail silently or terminate the process with
    exit code -1. */
+// fd 0 (콘솔 입력의 파일 디스크립터)으로 mmap을 시도합니다.
+// mmap은 조용히 실패하거나 프로세스를 -1 종료 코드로
+// 종료해야 합니다.
 
-#include <syscall.h>
-#include "tests/lib.h"
-#include "tests/main.h"
+#include <syscall.h>    // Pintos 시스템 콜 (mmap, CHECK, MAP_FAILED 등)을 사용하기 위해 포함합니다.
+#include "tests/lib.h"  // Pintos 테스트 라이브러리를 포함합니다.
+#include "tests/main.h" // 테스트 프레임워크의 메인 부분을 포함합니다.
 
 void
-test_main (void) 
+test_main (void)        // 테스트의 메인 함수입니다.
 {
-  CHECK (mmap ((void *) 0x10000000, 4096, 0, 0, 0) == MAP_FAILED,
-         "try to mmap stdin");
+    // 가상 주소 0x10000000에 4096 바이트 크기로 fd 0 (stdin)을 읽기 전용(세 번째 인자 0)으로 mmap 시도합니다.
+    // 이 호출은 MAP_FAILED를 반환해야 합니다. 성공 여부를 CHECK 합니다.
+    CHECK (mmap ((void *) 0x10000000, 4096, 0, 0, 0) == MAP_FAILED,
+           "try to mmap stdin");
 }
-

--- a/tests/vm/mmap-bad-fd3.c
+++ b/tests/vm/mmap-bad-fd3.c
@@ -1,16 +1,20 @@
 /* Tries to mmap with fd 1,
-   which is the file descriptor for console output. 
-	 mmap must fail silently or terminate the process with  
+   which is the file descriptor for console output.
+   mmap must fail silently or terminate the process with
    exit code -1. */
+// fd 1 (콘솔 출력의 파일 디스크립터)으로 mmap을 시도합니다.
+// mmap은 조용히 실패하거나 프로세스를 -1 종료 코드로
+// 종료해야 합니다.
 
 #include <syscall.h>
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  CHECK (mmap ((void *) 0x10000000, 4096, 0, 1, 0) == MAP_FAILED,
-         "try to mmap stdout");
+    // 가상 주소 0x10000000에 4096 바이트 크기로 fd 1 (stdout)을 읽기 전용(세 번째 인자 0)으로 mmap 시도합니다.
+    // 이 호출은 MAP_FAILED를 반환해야 합니다. 성공 여부를 CHECK 합니다.
+    CHECK (mmap ((void *) 0x10000000, 4096, 0, 1, 0) == MAP_FAILED,
+           "try to mmap stdout");
 }
-

--- a/tests/vm/mmap-bad-off.c
+++ b/tests/vm/mmap-bad-off.c
@@ -1,17 +1,23 @@
 /* Tries to mmap an invalid offset,
    which must either fail silently or terminate the process with
    exit code -1. */
+// 유효하지 않은 오프셋으로 mmap을 시도합니다.
+// 이는 조용히 실패하거나 프로세스를 -1 종료 코드로
+// 종료해야 합니다.
 
 #include <syscall.h>
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
-  CHECK ((handle = open ("large.txt")) > 1, "open \"large.txt\"");
+    int handle; // 파일 핸들을 저장할 변수입니다.
+    // "large.txt" 파일을 엽니다. 파일 핸들이 1보다 큰지 (유효한지) CHECK 합니다.
+    CHECK ((handle = open ("large.txt")) > 1, "open \"large.txt\"");
 
-  CHECK (mmap ((void *) 0x10000000, 4096, 0, handle, 0x1234) == MAP_FAILED,
-         "try to mmap invalid offset");
+    // 가상 주소 0x10000000에 4096 바이트 크기로, 파일 핸들 handle에 대해 오프셋 0x1234 (페이지 정렬 안됨)로 mmap을 시도합니다.
+    // 이 호출은 MAP_FAILED를 반환해야 합니다. 성공 여부를 CHECK 합니다.
+    CHECK (mmap ((void *) 0x10000000, 4096, 0, handle, 0x1234) == MAP_FAILED,
+           "try to mmap invalid offset");
 }

--- a/tests/vm/mmap-clean.c
+++ b/tests/vm/mmap-clean.c
@@ -1,5 +1,7 @@
 /* Verifies that mmap'd regions are only written back on munmap
    if the data was actually modified in memory. */
+// 메모리 맵된 영역의 데이터가 실제로 메모리에서 수정된 경우에만
+// munmap 시 파일에 다시 쓰여지는지 확인합니다.
 
 #include <string.h>
 #include <syscall.h>
@@ -8,47 +10,63 @@
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
+  // 파일에 덮어쓸 새로운 데이터입니다.
   static const char overwrite[] = "Now is the time for all good...";
+  // 파일 내용을 다시 읽어올 버퍼입니다. (sample 데이터의 크기 - 1 만큼)
   static char buffer[sizeof sample - 1];
-  char *actual = (char *) 0x54321000;
-  int handle;
-  void *map;
+  char *actual = (char *) 0x54321000; // 메모리 매핑을 위한 타겟 가상 주소입니다.
+  int handle;                         // 파일 핸들을 저장할 변수입니다.
+  void *map;                          // mmap 호출의 반환 값(매핑된 주소)을 저장할 포인터입니다.
 
   /* Open file, map, verify data. */
+  // 파일을 열고, 매핑하고, 데이터를 검증합니다.
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
- 
+
+  // actual 주소에 파일을 4096 바이트 크기만큼, 읽기 전용(세 번째 인자 0)으로 메모리 매핑합니다.
+  // 매핑 실패 여부를 CHECK 합니다.
 	CHECK ((map = mmap (actual, 4096, 0, handle, 0)) != MAP_FAILED, "mmap \"sample.txt\"");
+  // 매핑된 메모리(actual)의 내용이 원본 sample 데이터와 일치하는지 확인합니다.
   if (memcmp (actual, sample, strlen (sample)))
-    fail ("read of mmap'd file reported bad data");
+    fail ("read of mmap'd file reported bad data"); // 일치하지 않으면 테스트 실패입니다.
 
   /* Modify file. */
+  // 파일을 (매핑을 통하지 않고) 직접 수정합니다.
+  // overwrite 데이터를 파일에 직접 씁니다. 쓰기 성공 여부와 쓰여진 바이트 수를 CHECK 합니다.
   CHECK (write (handle, overwrite, strlen (overwrite))
          == (int) strlen (overwrite),
          "write \"sample.txt\"");
 
   /* Close mapping.  Data should not be written back, because we
      didn't modify it via the mapping. */
-  msg ("munmap \"sample.txt\"");
-  munmap (map);
+  // 매핑을 닫습니다. 데이터는 다시 쓰여져서는 안 됩니다. 왜냐하면
+  // 매핑을 통해 수정하지 않았기 때문입니다.
+  msg ("munmap \"sample.txt\""); // munmap 메시지를 출력합니다.
+  munmap (map); // 메모리 매핑을 해제합니다. `actual`은 수정되지 않았으므로, 이 때 파일에 쓰기 작업이 발생하면 안 됩니다.
 
   /* Read file back. */
-  msg ("seek \"sample.txt\"");
-  seek (handle, 0);
+  // 파일을 다시 읽습니다.
+  msg ("seek \"sample.txt\""); // seek 메시지를 출력합니다.
+  seek (handle, 0); // 파일 포인터를 파일의 시작으로 이동합니다.
+  // 파일 내용을 buffer로 읽어들입니다. 읽기 성공 여부와 읽은 바이트 수를 CHECK 합니다.
   CHECK (read (handle, buffer, sizeof buffer) == sizeof buffer,
          "read \"sample.txt\"");
 
   /* Verify that file overwrite worked. */
+  // 파일 덮어쓰기가 제대로 작동했는지 확인합니다.
+  // buffer의 내용이 overwrite 데이터와 일치하는지, 그리고 그 이후 부분은 원본 sample 데이터와 일치하는지 확인합니다.
   if (memcmp (buffer, overwrite, strlen (overwrite))
       || memcmp (buffer + strlen (overwrite), sample + strlen (overwrite),
-                 strlen (sample) - strlen (overwrite))) 
+                 strlen (sample) - strlen (overwrite)))
     {
+      // 만약 buffer 내용이 원본 sample 데이터와 같다면, munmap이 깨끗한 페이지를 잘못 덮어쓴 것입니다.
       if (!memcmp (buffer, sample, strlen (sample)))
         fail ("munmap wrote back clean page");
-      else
-        fail ("read surprising data from file"); 
+      else // 그렇지 않다면, 파일에서 예상치 못한 데이터를 읽은 것입니다.
+        fail ("read surprising data from file");
     }
-  else
+  else // 모든 것이 정상이라면, 파일 변경 사항이 munmap 이후에도 유지된 것입니다.
     msg ("file change was retained after munmap");
 }

--- a/tests/vm/mmap-close.c
+++ b/tests/vm/mmap-close.c
@@ -1,27 +1,32 @@
 /* Verifies that memory mappings persist after file close. */
+// 파일이 닫힌 후에도 메모리 매핑이 지속되는지 확인합니다.
 
 #include <string.h>
 #include <syscall.h>
 #include "tests/vm/sample.inc"
-#include "tests/arc4.h"
+#include "tests/arc4.h" // arc4 관련 기능은 이 파일에서 직접 사용되지 않는 것으로 보입니다.
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define ACTUAL ((void *) 0x10000000)
+#define ACTUAL ((void *) 0x10000000) // 메모리 매핑을 위한 타겟 가상 주소입니다.
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
-  void *map;
+  int handle;  // 파일 핸들을 저장할 변수입니다.
+  void *map;   // mmap 호출의 반환 값(매핑된 주소)을 저장할 포인터입니다.
 
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // ACTUAL 주소에 파일을 4096 바이트 크기만큼, 읽기 전용(세 번째 인자 0)으로 메모리 매핑합니다.
+  // 매핑 실패 여부를 CHECK 합니다.
   CHECK ((map = mmap(ACTUAL, 4096, 0, handle, 0)) != MAP_FAILED, "mmap \"sample.txt\"");
 
-  close (handle);
+  close (handle); // 파일 핸들을 닫습니다.
 
+  // 파일 핸들을 닫은 후에도 매핑된 메모리(ACTUAL)의 내용이 원본 sample 데이터와 일치하는지 확인합니다.
   if (memcmp (ACTUAL, sample, strlen (sample)))
-    fail ("read of mmap'd file reported bad data");
+    fail ("read of mmap'd file reported bad data"); // 일치하지 않으면 테스트 실패입니다.
 
-  munmap (map);
+  munmap (map); // 메모리 매핑을 해제합니다.
 }

--- a/tests/vm/mmap-exit.c
+++ b/tests/vm/mmap-exit.c
@@ -1,5 +1,7 @@
 /* Executes child-mm-wrt and verifies that the writes that should
    have occurred really did. */
+// child-mm-wrt를 실행하고, 발생했어야 하는 쓰기 작업이
+// 실제로 이루어졌는지 확인합니다.
 
 #include <syscall.h>
 #include "tests/vm/sample.inc"
@@ -7,20 +9,25 @@
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  pid_t child;
+	pid_t child;   // 자식 프로세스의 ID를 저장할 변수입니다.
 
-  /* Make child write file. */
-  quiet = true;
-	child = fork("child-mm-wrt");
-	if (child == 0) {
+	/* Make child write file. */
+	// 자식 프로세스가 파일을 쓰도록 합니다.
+	quiet = true; // 테스트 라이브러리의 상세 메시지 출력을 잠시 억제합니다.
+	child = fork("child-mm-wrt"); // "child-mm-wrt"라는 이름으로 자식 프로세스를 fork 합니다.
+	if (child == 0) { // 자식 프로세스인 경우
+		// "child-mm-wrt"를 실행합니다. exec 호출 성공 여부를 CHECK 합니다.
 		CHECK ((child = exec ("child-mm-wrt")) != -1, "exec \"child-mm-wrt\"");
-	} else {
+	} else { // 부모 프로세스인 경우
+		// 자식 프로세스가 종료될 때까지 기다립니다. 자식의 종료 코드가 0인지 CHECK 합니다.
 		CHECK (wait (child) == 0, "wait for child (should return 0)");
-		quiet = false;
-		
+		quiet = false; // 메시지 출력을 다시 활성화합니다.
+
 		/* Check file contents. */
+		// 파일 내용을 확인합니다.
+		// "sample.txt" 파일의 내용이 예상되는 sample 데이터와 일치하는지 확인합니다.
 		check_file ("sample.txt", sample, sizeof sample);
-	} 
+	}
 }

--- a/tests/vm/mmap-inherit.c
+++ b/tests/vm/mmap-inherit.c
@@ -1,5 +1,7 @@
 /* Maps a file into memory and runs child-inherit to verify that
    mappings are not inherited. */
+// 파일을 메모리에 매핑하고 child-inherit를 실행하여
+// 매핑이 상속되지 않는다는 것을 확인합니다.
 
 #include <string.h>
 #include <syscall.h>
@@ -8,29 +10,40 @@
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  char *actual = (char *) 0x54321000;
-  int handle;
-  pid_t child;
+	char *actual = (char *) 0x54321000; // 메모리 매핑을 위한 타겟 가상 주소입니다.
+	int handle;                         // 파일 핸들을 저장할 변수입니다.
+	pid_t child;                        // 자식 프로세스의 ID를 저장할 변수입니다.
 
-  /* Open file, map, verify data. */
-  CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
-  CHECK (mmap (actual, 4096, 0, handle, 0) != MAP_FAILED, "mmap \"sample.txt\"");
-  if (memcmp (actual, sample, strlen (sample)))
-    fail ("read of mmap'd file reported bad data");
+	/* Open file, map, verify data. */
+	// 파일을 열고, 매핑하고, 데이터를 검증합니다.
+	// "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
+	CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+	// actual 주소에 파일을 4096 바이트 크기만큼, 읽기 전용(세 번째 인자 0)으로 메모리 매핑합니다.
+	// 매핑 실패 여부를 CHECK 합니다.
+	CHECK (mmap (actual, 4096, 0, handle, 0) != MAP_FAILED, "mmap \"sample.txt\"");
+	// 매핑된 메모리(actual)의 내용이 원본 sample 데이터와 일치하는지 확인합니다.
+	if (memcmp (actual, sample, strlen (sample)))
+		fail ("read of mmap'd file reported bad data"); // 일치하지 않으면 테스트 실패입니다.
 
 	/* Spawn child and wait. */
-	child = fork("child-inherit");
-	if (child == 0) {
+	// 자식 프로세스를 생성하고 기다립니다.
+	child = fork("child-inherit"); // "child-inherit"라는 이름으로 자식 프로세스를 fork 합니다.
+	if (child == 0) { // 자식 프로세스인 경우
+		// "child-inherit"를 실행합니다. exec 호출 성공 여부를 CHECK 합니다.
 		CHECK (exec ("child-inherit") != -1, "exec \"child-inherit\"");
-	}	else {
-		quiet = true;
+	}	else { // 부모 프로세스인 경우
+		quiet = true; // 테스트 라이브러리의 상세 메시지 출력을 잠시 억제합니다.
+		// 자식 프로세스가 종료될 때까지 기다립니다. 자식의 종료 코드가 -1인지 CHECK 합니다.
 		CHECK (wait (child) == -1, "wait for child (should return -1)");
-		quiet = false;
+		quiet = false; // 메시지 출력을 다시 활성화합니다.
 	}
 
-  /* Verify data again. */
-  CHECK (!memcmp (actual, sample, strlen (sample)),
-         "checking that mmap'd file still has same data");
+	/* Verify data again. */
+	// 데이터를 다시 검증합니다.
+	// 자식 프로세스의 작업 후에도 부모의 매핑된 메모리 내용이 원본 sample 데이터와 여전히 일치하는지 확인합니다.
+	// (자식의 쓰기 시도는 실패했어야 하므로 부모의 데이터나 파일은 변경되지 않았어야 합니다.)
+	CHECK (!memcmp (actual, sample, strlen (sample)),
+		   "checking that mmap'd file still has same data");
 }

--- a/tests/vm/mmap-kernel.c
+++ b/tests/vm/mmap-kernel.c
@@ -1,4 +1,5 @@
 /* Verifies that mapping over the kernel is disallowed. */
+// 커널 위로 매핑하는 것이 금지되는지 확인합니다.
 
 #include <stdint.h>
 #include <syscall.h>
@@ -6,22 +7,30 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
-  
+  int handle; // 파일 핸들을 저장할 변수입니다.
+
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
-  
+
+  // 커널 공간으로 예상되는 주소 0x8004000000 에 mmap을 시도합니다.
+  // 이 호출은 MAP_FAILED를 반환해야 합니다.
   void *kernel = (void *) 0x8004000000;
   CHECK (mmap (kernel, 4096, 0, handle, 0) == MAP_FAILED,
          "try to mmap over kernel 0");
 
+  // 또 다른 커널 공간으로 예상되는 높은 주소 0xfffffffffffff000 에 mmap을 시도합니다.
+  // 이 호출은 MAP_FAILED를 반환해야 합니다.
   kernel = (void *) 0xfffffffffffff000;
   CHECK (mmap (kernel, 0x2000, 0, handle, 0) == MAP_FAILED,
          "try to mmap over kernel 1");
 
+  // 커널 시작 주소 바로 이전부터 시작하여 커널 공간을 침범하는 영역에 mmap을 시도합니다.
+  // (주: 세 번째 mmap의 크기 인자가 음수처럼 보이나, size_t로 해석되면 매우 큰 양수가 될 수 있습니다.
+  // 의도는 커널 영역을 겹치도록 매핑하는 것입니다.)
+  // 이 호출은 MAP_FAILED를 반환해야 합니다.
   kernel = (void *) 0x8004000000 - 0x1000;
-  CHECK (mmap (kernel, -0x8004000000 + 0x1000, 0, handle, 0) == MAP_FAILED,
+  CHECK (mmap (kernel, (size_t)((uintptr_t)-0x8004000000 + (uintptr_t)0x1000), 0, handle, 0) == MAP_FAILED,
          "try to mmap over kernel 2");
-
 }

--- a/tests/vm/mmap-misalign.c
+++ b/tests/vm/mmap-misalign.c
@@ -1,16 +1,19 @@
 /* Verifies that misaligned memory mappings are disallowed. */
+// 정렬되지 않은 메모리 매핑이 금지되는지 확인합니다.
 
 #include <syscall.h>
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
-  
+  int handle; // 파일 핸들을 저장할 변수입니다.
+
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // 페이지 정렬되지 않은 주소 0x10001234 (페이지 크기가 4096일 경우)에 mmap을 시도합니다.
+  // 이 호출은 MAP_FAILED를 반환해야 합니다.
   CHECK (mmap ((void *) 0x10001234, 4096, 0, handle, 0) == MAP_FAILED,
          "try to mmap at misaligned address");
 }
-

--- a/tests/vm/mmap-null.c
+++ b/tests/vm/mmap-null.c
@@ -1,15 +1,18 @@
 /* Verifies that memory mappings at address 0 are disallowed. */
+// 주소 0에서의 메모리 매핑이 금지되는지 확인합니다.
 
 #include <syscall.h>
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
-  
+  int handle; // 파일 핸들을 저장할 변수입니다.
+
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // NULL 주소 (0)에 mmap을 시도합니다.
+  // 이 호출은 MAP_FAILED를 반환해야 합니다.
   CHECK (mmap (NULL, 4096, 0, handle, 0) == MAP_FAILED, "try to mmap at address 0");
 }
-

--- a/tests/vm/mmap-off.c
+++ b/tests/vm/mmap-off.c
@@ -1,54 +1,70 @@
 /* Tries to mmap with offset > 0. */
+/* 파일의 특정 오프셋(0보다 큰 값)에서부터 메모리 매핑(mmap)을 시도하고,
+ * 해당 매핑된 메모리 영역을 읽고 쓰는 기능을 테스트합니다.
+ * 오프셋으로 매핑된 영역의 데이터가 파일의 해당 부분과 일치하는지,
+ * 그리고 매핑된 영역에 쓴 내용이 실제로 파일에 반영되는지 확인합니다. */
 
 #include <syscall.h>
 #include <string.h>
 #include "tests/lib.h"
 #include "tests/main.h"
-#include "tests/vm/large.inc"
-static char zeros[0x1000];
+#include "tests/vm/large.inc" // 'large' 배열 (테스트용 대용량 데이터)을 포함합니다.
+
+static char zeros[0x1000]; // 0x1000 (4096) 바이트 크기의 0으로 채워진 배열을 선언합니다 (bss 영역).
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
-  char buf[0x1000];
+  int handle;             // 파일 핸들을 저장할 변수입니다.
+  char buf[0x1000];       // 파일에서 데이터를 읽어올 4KB 크기의 버퍼입니다.
 
+  // "large.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다. (large.txt는 large 데이터로 미리 만들어져 있어야 함)
   CHECK ((handle = open ("large.txt")) > 1, "open \"large.txt\"");
 
+  // 가상 주소 0x10000000에 "large.txt" 파일의 오프셋 0x1000 (4096번째 바이트)부터 4096 바이트를 쓰기 가능(prot=1)으로 매핑합니다.
+  // mmap 호출 결과가 매핑 요청 주소와 같은지 (성공적인지) CHECK 합니다.
   CHECK (mmap ((void *) 0x10000000, 4096, 1, handle, 0x1000) == (void *) 0x10000000,
           "try to mmap with offset 0x1000");
-  close (handle);
+  close (handle); // 파일 핸들을 닫습니다. mmap 이후에는 일반적으로 닫아도 매핑은 유지됩니다.
 
-  msg ("validate mmap.");
+  msg ("validate mmap."); // mmap 유효성 검사 메시지를 출력합니다.
+  // 매핑된 메모리 영역(0x10000000)의 내용이 large 데이터의 0x1000 오프셋부터의 내용과 일치하는지 확인합니다.
   if (!memcmp ((void *) 0x10000000, &large[0x1000], 0x1000))
-      msg ("validated.");
+      msg ("validated."); // 일치하면 유효성 검사 성공 메시지를 출력합니다.
   else
-      fail ("validate fail.");
+      fail ("validate fail."); // 일치하지 않으면 테스트 실패를 알립니다.
 
-  msg ("write to mmap");
-  memset (zeros, 0, 0x1000);
+  msg ("write to mmap"); // mmap에 쓰기 작업 메시지를 출력합니다.
+  memset (zeros, 0, 0x1000); // zeros 배열을 0으로 채웁니다 (이미 0으로 초기화되어 있지만 명시적으로).
+  // 매핑된 메모리 영역(0x10000000)에 zeros 배열의 내용(0으로 채워진 4KB)을 복사합니다.
   memcpy ((void *) 0x10000000, zeros, 0x1000);
-  munmap ((void *) 0x10000000);
+  munmap ((void *) 0x10000000); // 메모리 매핑을 해제합니다. 이때 변경된 내용이 파일에 반영되어야 합니다.
 
-  msg ("validate contents.");
+  msg ("validate contents."); // 내용 유효성 검사 메시지를 출력합니다.
 
+  // "large.txt" 파일을 다시 엽니다.
   CHECK ((handle = open ("large.txt")) > 1, "open \"large.txt\"");
+  // 파일의 첫 번째 페이지(0~0x1000-1)를 읽습니다. 읽은 바이트 수가 0x1000인지 CHECK 합니다.
   CHECK (0x1000 == read (handle, buf, 0x1000), "read \"large.txt\" Page 0");
 
-  msg ("validate page 0.");
+  msg ("validate page 0."); // 페이지 0 유효성 검사 메시지를 출력합니다.
+  // 읽어온 첫 번째 페이지(buf)의 내용이 원본 large 데이터의 첫 페이지 내용과 일치하는지 확인합니다.
+  // (이 부분은 mmap 오프셋 쓰기와는 직접 관련 없으나, 파일의 다른 부분이 변경되지 않았는지 확인)
   if (!memcmp ((void *) buf, large, 0x1000))
-      msg ("validated.");
+      msg ("validated."); // 일치하면 유효성 검사 성공 메시지를 출력합니다.
   else
-      fail ("validate fail.");
+      fail ("validate fail."); // 일치하지 않으면 테스트 실패를 알립니다.
 
+  // 파일의 두 번째 페이지(0x1000~0x2000-1)를 읽습니다. 읽은 바이트 수가 0x1000인지 CHECK 합니다.
   CHECK (0x1000 == read (handle, buf, 0x1000), "read \"large.txt\" Page 1");
 
-  msg ("validate page 1.");
+  msg ("validate page 1."); // 페이지 1 유효성 검사 메시지를 출력합니다.
+  // 읽어온 두 번째 페이지(buf)의 내용이 이전에 mmap을 통해 썼던 zeros 배열의 내용(모두 0)과 일치하는지 확인합니다.
   if (!memcmp ((void *) buf, zeros, 0x1000))
-      msg ("validated.");
+      msg ("validated."); // 일치하면 유효성 검사 성공 메시지를 출력합니다.
   else
-      fail ("validate fail.");
-  close (handle);
+      fail ("validate fail."); // 일치하지 않으면 테스트 실패를 알립니다.
+  close (handle); // 파일 핸들을 닫습니다.
 
-  msg ("success");
+  msg ("success"); // 모든 검사를 통과하면 성공 메시지를 출력합니다.
 }

--- a/tests/vm/mmap-over-code.c
+++ b/tests/vm/mmap-over-code.c
@@ -1,4 +1,5 @@
 /* Verifies that mapping over the code segment is disallowed. */
+//  프로그램의 코드 세그먼트(실행 가능한 명령어들이 있는 메모리 영역) 위로 메모리 매핑(mmap)을 시도하는 것이 금지되어 실패하는지 확인합니다.
 
 #include <stdint.h>
 #include <round.h>
@@ -7,13 +8,17 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  uintptr_t test_main_page = ROUND_DOWN ((uintptr_t) test_main, 4096);
-  int handle;
-  
-  CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
-  CHECK (mmap ((void *) test_main_page, 4096, 0, handle, 0) == MAP_FAILED,
-         "try to mmap over code segment");
-}
+    // 현재 실행 중인 test_main 함수의 시작 주소를 가져와 페이지 경계로 내림(ROUND_DOWN)합니다.
+    // 이것이 코드 세그먼트 내의 한 페이지 주소가 됩니다.
+    uintptr_t test_main_page = ROUND_DOWN ((uintptr_t) test_main, 4096);
+    int handle; // 파일 핸들을 저장할 변수입니다.
 
+    // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
+    CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+    // 코드 세그먼트 내의 페이지(test_main_page)에 "sample.txt" 파일을 4096 바이트 크기로 mmap 하려고 시도합니다.
+    // 이 호출은 MAP_FAILED를 반환해야 합니다. (코드 영역 덮어쓰기 시도)
+    CHECK (mmap ((void *) test_main_page, 4096, 0, handle, 0) == MAP_FAILED,
+           "try to mmap over code segment");
+}

--- a/tests/vm/mmap-over-data.c
+++ b/tests/vm/mmap-over-data.c
@@ -1,4 +1,6 @@
 /* Verifies that mapping over the data segment is disallowed. */
+// 프로그램의 데이터 세그먼트(초기화된 전역 변수나 정적 변수들이 있는 메모리 영역)
+// 위로 메모리 매핑(mmap)을 시도하는 것이 금지되어 실패하는지 확인합니다.
 
 #include <stdint.h>
 #include <round.h>
@@ -6,16 +8,20 @@
 #include "tests/lib.h"
 #include "tests/main.h"
 
-static char x;
+static char x; // 데이터 세그먼트에 위치할 정적 변수입니다.
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
+  // 정적 변수 x의 주소를 가져와 페이지 경계로 내림(ROUND_DOWN)합니다.
+  // 이것이 데이터 세그먼트 내의 한 페이지 주소가 됩니다.
   uintptr_t x_page = ROUND_DOWN ((uintptr_t) &x, 4096);
-  int handle;
-  
+  int handle; // 파일 핸들을 저장할 변수입니다.
+
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // 데이터 세그먼트 내의 페이지(x_page)에 "sample.txt" 파일을 4096 바이트 크기로 mmap 하려고 시도합니다.
+  // 이 호출은 MAP_FAILED를 반환해야 합니다. (데이터 영역 덮어쓰기 시도)
   CHECK (mmap ((void *) x_page, 4096, 0, handle, 0) == MAP_FAILED,
          "try to mmap over data segment");
 }
-

--- a/tests/vm/mmap-over-stk.c
+++ b/tests/vm/mmap-over-stk.c
@@ -1,4 +1,6 @@
 /* Verifies that mapping over the stack segment is disallowed. */
+// 프로그램의 스택 세그먼트(함수 호출 시 지역 변수, 반환 주소 등이 저장되는 메모리 영역)
+// 위로 메모리 매핑(mmap)을 시도하는 것이 금지되어 실패하는지 확인합니다.
 
 #include <stdint.h>
 #include <round.h>
@@ -7,13 +9,18 @@
 #include "tests/main.h"
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
+  int handle; // 파일 핸들을 저장할 변수 (스택에 위치).
+  // 지역 변수 handle의 주소를 가져와 페이지 경계로 내림(ROUND_DOWN)합니다.
+  // 이것이 스택 세그먼트 내의 한 페이지 주소가 됩니다.
   uintptr_t handle_page = ROUND_DOWN ((uintptr_t) &handle, 4096);
-  
+
+  // "sample.txt" 파일을 엽니다. (이 handle 변수는 위에서 주소 계산에 사용된 handle과 다름)
+  // 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // 스택 세그먼트 내의 페이지(handle_page)에 "sample.txt" 파일을 4096 바이트 크기로 mmap 하려고 시도합니다.
+  // 이 호출은 MAP_FAILED를 반환해야 합니다. (스택 영역 덮어쓰기 시도)
   CHECK (mmap ((void *) handle_page, 4096, 0, handle, 0) == MAP_FAILED,
          "try to mmap over stack segment");
 }
-

--- a/tests/vm/mmap-overlap.c
+++ b/tests/vm/mmap-overlap.c
@@ -1,21 +1,30 @@
 /* Verifies that overlapping memory mappings are disallowed. */
+/* 이미 사용 중인 메모리 영역에 또 다른 메모리 매핑(mmap)을 시도하여,
+ * 즉 메모리 매핑이 서로 겹치도록 하려는 시도가 금지되어 실패하는지 확인합니다. */
 
 #include <syscall.h>
-#include "tests/vm/sample.inc"
+#include "tests/vm/sample.inc" // sample 데이터는 직접 사용되지 않으나, 파일 시스템 테스트를 위한 파일 생성 시 필요할 수 있음.
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  char *start = (char *) 0x10000000;
-  int fd[2];
+  char *start = (char *) 0x10000000; // 메모리 매핑을 위한 시작 가상 주소입니다.
+  int fd[2];                          // 두 개의 파일 디스크립터를 저장할 배열입니다.
 
+  // "zeros"라는 파일을 엽니다 (이 파일은 0으로 채워진 파일이거나, 테스트 전에 생성되어야 함).
+  // 파일 핸들을 fd[0]에 저장하고 성공 여부를 CHECK 합니다.
   CHECK ((fd[0] = open ("zeros")) > 1, "open \"zeros\" once");
+  // start 주소에 "zeros" 파일을 4096 바이트 크기로 mmap 합니다.
+  // 매핑 성공 여부(MAP_FAILED가 아닌지)를 CHECK 합니다.
   CHECK (mmap (start, 4096, 0, fd[0], 0) != MAP_FAILED, "mmap \"zeros\"");
 
+  // "zeros" 파일을 다시 엽니다. 이전 fd[0]과 다른 핸들인지, 그리고 열기 성공 여부를 CHECK 합니다.
   CHECK ((fd[1] = open ("zeros")) > 1 && fd[0] != fd[1],
          "open \"zeros\" again");
+  // 이전에 매핑된 동일한 start 주소에 "zeros" 파일을 다시 mmap 하려고 시도합니다 (겹치는 매핑).
+  // 이 호출은 MAP_FAILED를 반환해야 합니다.
   CHECK (mmap (start, 4096, 0, fd[1], 0) == MAP_FAILED,
          "try to mmap \"zeros\" again");
 }

--- a/tests/vm/mmap-read.c
+++ b/tests/vm/mmap-read.c
@@ -1,32 +1,42 @@
 /* Uses a memory mapping to read a file. */
+/* 메모리 매핑(mmap)을 사용하여 파일의 내용을 읽고, 읽어들인 데이터가 원본 파일의 내용과 일치하는지,
+ * 그리고 매핑된 영역에서 파일 내용 이후의 부분이 0으로 채워져 있는지 확인합니다 */
 
 #include <string.h>
 #include <syscall.h>
-#include "tests/vm/sample.inc"
+#include "tests/vm/sample.inc" // 'sample' 배열 (테스트용 샘플 데이터)을 포함합니다.
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  char *actual = (char *) 0x10000000;
-  int handle;
-  void *map;
-  size_t i;
+  char *actual = (char *) 0x10000000; // 메모리 매핑을 위한 타겟 가상 주소입니다.
+  int handle;                         // 파일 핸들을 저장할 변수입니다.
+  void *map;                          // mmap 호출의 반환 값(매핑된 주소)을 저장할 포인터입니다.
+  size_t i;                           // 반복문에서 사용할 인덱스 변수입니다.
 
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // actual 주소에 "sample.txt" 파일을 4096 바이트 크기만큼, 읽기 전용(세 번째 인자 0)으로 메모리 매핑합니다.
+  // 매핑 성공 여부(MAP_FAILED가 아닌지)를 CHECK 합니다.
   CHECK ((map = mmap (actual, 4096, 0, handle, 0)) != MAP_FAILED, "mmap \"sample.txt\"");
 
   /* Check that data is correct. */
+  // 데이터가 올바른지 확인합니다.
+  // 매핑된 메모리(actual)의 내용이 원본 sample 데이터와 일치하는지 확인합니다.
   if (memcmp (actual, sample, strlen (sample)))
-    fail ("read of mmap'd file reported bad data");
+    fail ("read of mmap'd file reported bad data"); // 일치하지 않으면 테스트 실패를 알립니다.
 
   /* Verify that data is followed by zeros. */
+  // 데이터 뒤에 0이 오는지 확인합니다.
+  // sample 데이터 길이 이후부터 페이지 끝(4096 바이트)까지 순회합니다.
   for (i = strlen (sample); i < 4096; i++)
-    if (actual[i] != 0)
-      fail ("byte %zu of mmap'd region has value %02hhx (should be 0)",
-            i, actual[i]);
+    if (actual[i] != 0) // 해당 바이트가 0이 아니면,
+      // 오류 메시지를 출력하고 테스트 실패를 알립니다.
+        fail ("byte %zu of mmap'd region has value %02hhx (should be 0)",
+              i, actual[i]);
 
-  munmap (map);
-  close (handle);
+  munmap (map);   // 메모리 매핑을 해제합니다.
+  close (handle); // 파일을 닫습니다.
 }

--- a/tests/vm/mmap-remove.c
+++ b/tests/vm/mmap-remove.c
@@ -1,43 +1,60 @@
 /* Deletes and closes file that is mapped into memory
    and verifies that it can still be read through the mapping. */
+/* 파일을 메모리에 매핑한 후, 해당 파일을 닫고 시스템에서 삭제합니다.
+ * 그 후에도 여전히 매핑된 메모리를 통해 파일의 원본 데이터를 읽을 수 있는지 확인합니다.
+ * 이는 파일이 삭제되더라도, 해당 파일 내용을 참조하는 활성 메모리 매핑이 있다면
+ * 그 내용은 계속 유효해야 함을 테스트합니다 */
 
 #include <string.h>
 #include <syscall.h>
-#include "tests/vm/sample.inc"
+#include "tests/vm/sample.inc" // 'sample' 배열 (테스트용 샘플 데이터)을 포함합니다.
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  char *actual = (char *) 0x10000000;
-  int handle;
-  void *map;
-  size_t i;
+  char *actual = (char *) 0x10000000; // 메모리 매핑을 위한 타겟 가상 주소입니다.
+  int handle;                         // 파일 핸들을 저장할 변수입니다.
+  void *map;                          // mmap 호출의 반환 값(매핑된 주소)을 저장할 포인터입니다.
+  size_t i;                           // 반복문에서 사용할 인덱스 변수입니다.
 
   /* Map file. */
+  // 파일을 매핑합니다.
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // actual 주소에 "sample.txt" 파일을 4096 바이트 크기만큼, 읽기 전용(세 번째 인자 0)으로 메모리 매핑합니다.
+  // 매핑 성공 여부(MAP_FAILED가 아닌지)를 CHECK 합니다.
   CHECK ((map = mmap (actual, 4096, 0, handle, 0)) != MAP_FAILED, "mmap \"sample.txt\"");
 
   /* Close file and delete it. */
-  close (handle);
-  CHECK (remove ("sample.txt"), "remove \"sample.txt\"");
+  // 파일을 닫고 삭제합니다.
+  close (handle); // 파일 핸들을 닫습니다.
+  CHECK (remove ("sample.txt"), "remove \"sample.txt\""); // "sample.txt" 파일을 삭제합니다. 성공 여부를 CHECK 합니다.
+  // 삭제된 "sample.txt" 파일을 다시 열려고 시도합니다. open 호출이 -1을 반환하는지(실패하는지) CHECK 합니다.
   CHECK (open ("sample.txt") == -1, "try to open \"sample.txt\"");
 
   /* Create a new file in hopes of overwriting data from the old
      one, in case the file system has incorrectly freed the
      file's data. */
-  CHECK (create ("another", 4096 * 10), "create \"another\"");
+  // 파일 시스템이 이전 파일의 데이터를 잘못 해제했을 경우를 대비하여,
+  // 이전 파일의 데이터를 덮어쓸 목적으로 새 파일을 생성합니다.
+  CHECK (create ("another", 4096 * 10), "create \"another\""); // "another"라는 이름으로 새 파일을 생성합니다.
 
   /* Check that mapped data is correct. */
+  // 매핑된 데이터가 올바른지 확인합니다.
+  // (파일이 삭제되었음에도 불구하고) 매핑된 메모리(actual)의 내용이 원본 sample 데이터와 일치하는지 확인합니다.
   if (memcmp (actual, sample, strlen (sample)))
-    fail ("read of mmap'd file reported bad data");
+    fail ("read of mmap'd file reported bad data"); // 일치하지 않으면 테스트 실패를 알립니다.
 
   /* Verify that data is followed by zeros. */
+  // 데이터 뒤에 0이 오는지 확인합니다.
+  // sample 데이터 길이 이후부터 페이지 끝(4096 바이트)까지 순회합니다.
   for (i = strlen (sample); i < 4096; i++)
-    if (actual[i] != 0)
+    if (actual[i] != 0) // 해당 바이트가 0이 아니면,
+      // 오류 메시지를 출력하고 테스트 실패를 알립니다.
       fail ("byte %zu of mmap'd region has value %02hhx (should be 0)",
             i, actual[i]);
 
-  munmap (map);
+  munmap (map); // 메모리 매핑을 해제합니다.
 }

--- a/tests/vm/mmap-ro.c
+++ b/tests/vm/mmap-ro.c
@@ -1,27 +1,36 @@
 /* Writes to a file through a mapping, and unmaps the file,
    then reads the data in the file back using the read system
    call to verify. */
+// (주석 설명은 실제 테스트 내용과 약간 다름. 실제로는 읽기 전용 매핑에 쓰기를 시도함)
+/* 파일을 읽기 전용(read-only)으로 메모리 매핑한 후, 해당 매핑된 메모리 영역에 쓰기를 시도합니다.
+ * 이 쓰기 시도는 실패하거나 세그멘테이션 폴트(segmentation fault)와 같은 오류를 발생시켜야 합니다.
+ * (주: 이 테스트 코드 자체는 쓰기 시도 후 프로그램이 비정상 종료될 것을 예상하는 방식으로 작성되어 있으며,
+ * msg ("Error should have occured"); 이후 코드가 실행되지 않아야 성공입니다.) */
 
 #include <string.h>
 #include <syscall.h>
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define ACTUAL ((void *) 0x10000000)
+#define ACTUAL ((void *) 0x10000000) // 메모리 매핑을 위한 타겟 가상 주소입니다.
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
-  void *map;
-  char buf[1024];
+  int handle;  // 파일 핸들을 저장할 변수입니다.
+  void *map;   // mmap 호출의 반환 값(매핑된 주소)을 저장할 포인터입니다.
+  // char buf[1024]; // 이 변수는 실제 코드에서 사용되지 않습니다.
 
   /* Write file via mmap. */
+  // mmap을 통해 파일에 쓰기를 시도합니다. (실제로는 읽기 전용 매핑)
+  // "large.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("large.txt")) > 1, "open \"large.txt\"");
+  // ACTUAL 주소에 "large.txt" 파일을 4096 바이트 크기만큼, 읽기 전용(세 번째 인자 0)으로 메모리 매핑합니다.
+  // 매핑 성공 여부(MAP_FAILED가 아닌지)를 CHECK 합니다.
   CHECK ((map = mmap (ACTUAL, 4096, 0, handle, 0)) != MAP_FAILED, "mmap \"large.txt\" with writable=0");
-  msg ("about to write into read-only mmap'd memory");
-  *((int *)map) = 0;
-  msg ("Error should have occured");
-  munmap (map);
-  close (handle);
+  msg ("about to write into read-only mmap'd memory"); // 읽기 전용으로 매핑된 메모리에 쓰기를 시도할 것이라는 메시지를 출력합니다.
+  *((int *)map) = 0; // 읽기 전용으로 매핑된 메모리의 시작 부분에 정수 0을 쓰려고 시도합니다. 여기서 오류(예: 페이지 폴트 핸들러에 의한 종료)가 발생해야 합니다.
+  msg ("Error should have occured"); // 이 메시지가 출력된다면, 읽기 전용 매핑에 쓰기가 허용된 것이므로 테스트 실패입니다.
+  munmap (map);   // 오류로 인해 이 코드가 실행되지 않아야 합니다.
+  close (handle); // 오류로 인해 이 코드가 실행되지 않아야 합니다.
 }

--- a/tests/vm/mmap-shuffle.c
+++ b/tests/vm/mmap-shuffle.c
@@ -1,38 +1,53 @@
 /* Creates a 128 kB file and repeatedly shuffles data in it
-   through a memory mapping. */
+through a memory mapping. */
+/* 128KB 크기의 파일을 생성하고, 해당 파일을 메모리에 매핑한 후,
+ * 매핑된 메모리 영역 내의 데이터를 반복적으로 섞습니다(shuffle).
+ * 각 셔플 단계 후 데이터의 체크섬(cksum)을 계산하여 데이터가 실제로 변경되고 있음을 (간접적으로) 보여줍니다. */
 
 #include <stdio.h>
 #include <string.h>
 #include <syscall.h>
-#include "tests/arc4.h"
-#include "tests/cksum.h"
+#include "tests/arc4.h"    // shuffle 함수를 사용하기 위해 포함합니다.
+#include "tests/cksum.h"   // cksum 함수를 사용하기 위해 포함합니다.
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define SIZE (128 * 1024)
+#define SIZE (128 * 1024) // 파일 및 버퍼의 크기를 128KB로 정의합니다.
 
-static char *buf = (char *) 0x10000000;
+static char *buf = (char *) 0x10000000; // 메모리 매핑을 위한 타겟 가상 주소 (128KB 영역을 가리킴)
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  size_t i;
-  int handle;
+  size_t i;      // 반복문에서 사용할 인덱스 변수입니다.
+  int handle;    // 파일 핸들을 저장할 변수입니다.
 
   /* Create file, mmap. */
+  // 파일을 생성하고 매핑합니다.
+  // "buffer"라는 이름으로 SIZE만큼의 파일을 생성합니다. 성공 여부를 CHECK 합니다.
   CHECK (create ("buffer", SIZE), "create \"buffer\"");
+  // "buffer" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("buffer")) > 1, "open \"buffer\"");
+  // buf 주소에 "buffer" 파일을 SIZE만큼, 쓰기 가능(세 번째 인자 1)으로 메모리 매핑합니다.
+  // 매핑 성공 여부(MAP_FAILED가 아닌지)를 CHECK 합니다.
   CHECK (mmap (buf, SIZE, 1, handle, 0) != MAP_FAILED, "mmap \"buffer\"");
 
   /* Initialize. */
+  // 데이터를 초기화합니다.
+  // 매핑된 버퍼(buf)의 각 바이트를 특정 값 (i * 257)으로 초기화합니다.
   for (i = 0; i < SIZE; i++)
     buf[i] = i * 257;
+  // 초기화된 데이터의 체크섬을 계산하고 출력합니다.
   msg ("init: cksum=%lu", cksum (buf, SIZE));
 
   /* Shuffle repeatedly. */
+  // 반복적으로 섞습니다.
+  // 10번 반복합니다.
   for (i = 0; i < 10; i++)
-    {
-      shuffle (buf, SIZE, 1);
-      msg ("shuffle %zu: cksum=%lu", i, cksum (buf, SIZE));
-    }
+  {
+    shuffle (buf, SIZE, 1); // 매핑된 버퍼(buf)의 데이터를 섞습니다. (1은 섞는 횟수 또는 강도를 의미할 수 있음)
+    // 섞인 후 데이터의 체크섬을 계산하고 출력합니다.
+    msg ("shuffle %zu: cksum=%lu", i, cksum (buf, SIZE));
+  }
+  // munmap이나 close는 이 테스트에서 명시적으로 호출되지 않을 수 있습니다 (프로세스 종료 시 정리).
 }

--- a/tests/vm/mmap-twice.c
+++ b/tests/vm/mmap-twice.c
@@ -1,28 +1,38 @@
 /* Maps the same file into memory twice and verifies that the
    same data is readable in both. */
+/* 동일한 파일을 메모리에 두 번 매핑하고
+ * 두 곳 모두에서 동일한 데이터를 읽을 수 있는지 확인합니다. */
 
 #include <string.h>
 #include <syscall.h>
-#include "tests/vm/sample.inc"
+#include "tests/vm/sample.inc" // 'sample' 배열 (테스트용 샘플 데이터)을 포함합니다.
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
+  // 두 개의 메모리 매핑 영역을 위한 타겟 가상 주소 배열입니다.
   char *actual[2] = {(char *) 0x10000000, (char *) 0x20000000};
-  size_t i;
-  int handle[2];
+  size_t i;        // 반복문에서 사용할 인덱스 변수입니다.
+  int handle[2];   // 두 개의 파일 디스크립터를 저장할 배열입니다.
 
-  for (i = 0; i < 2; i++) 
+  // 2번 반복하여 파일을 열고 매핑합니다.
+  for (i = 0; i < 2; i++)
     {
+      // "sample.txt" 파일을 엽니다. 파일 핸들을 handle[i]에 저장하고 성공 여부를 CHECK 합니다.
       CHECK ((handle[i] = open ("sample.txt")) > 1,
              "open \"sample.txt\" #%zu", i);
+      // actual[i] 주소에 "sample.txt" 파일을 4096 바이트 크기만큼, 읽기 전용(세 번째 인자 0)으로 메모리 매핑합니다.
+      // 매핑 성공 여부(MAP_FAILED가 아닌지)를 CHECK 합니다.
       CHECK (mmap (actual[i], 4096, 0, handle[i], 0) != MAP_FAILED,
              "mmap \"sample.txt\" #%zu at %p", i, (void *) actual[i]);
     }
 
+  // 2개의 매핑된 영역을 순회하며 내용을 확인합니다.
   for (i = 0; i < 2; i++)
+    // 각 매핑된 메모리(actual[i])의 내용이 원본 sample 데이터와 일치하는지 확인합니다.
     CHECK (!memcmp (actual[i], sample, strlen (sample)),
            "compare mmap'd file %zu against data", i);
+  // munmap이나 close는 이 테스트에서 명시적으로 호출되지 않을 수 있습니다 (프로세스 종료 시 정리).
 }

--- a/tests/vm/mmap-unmap.c
+++ b/tests/vm/mmap-unmap.c
@@ -1,27 +1,38 @@
 /* Maps and unmaps a file and verifies that the mapped region is
    inaccessible afterward. */
+/* 파일을 매핑하고 언매핑한 후, 매핑되었던 영역이
+ * 이후에 접근 불가능한지 확인합니다.*/
 
 #include <syscall.h>
-#include "tests/vm/sample.inc"
+#include "tests/vm/sample.inc" // sample 데이터는 직접 사용되지 않으나, 파일 시스템 테스트를 위한 파일 생성 시 필요할 수 있음.
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define ACTUAL ((void *) 0x10000000)
+#define ACTUAL ((void *) 0x10000000) // 메모리 매핑을 위한 타겟 가상 주소입니다.
 
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
-  void *map;
+  int handle;  // 파일 핸들을 저장할 변수입니다.
+  void *map;   // mmap 호출의 반환 값(매핑된 주소)을 저장할 포인터입니다.
 
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // ACTUAL 주소에 "sample.txt" 파일을 0x2000 (8KB) 바이트 크기만큼, 읽기 전용(세 번째 인자 0)으로 메모리 매핑합니다.
+  // 매핑 성공 여부(MAP_FAILED가 아닌지)를 CHECK 합니다.
   CHECK ((map = mmap (ACTUAL, 0x2000, 0, handle, 0)) != MAP_FAILED, "mmap \"sample.txt\"");
+  // 매핑된 메모리(ACTUAL)의 첫 부분을 읽을 수 있는지 확인하는 메시지 (실제 접근 시도).
   msg ("memory is readable %d", *(int *) ACTUAL);
-  msg ("memory is readable %d", *(int *) ACTUAL + 0x1000);
+  // 매핑된 메모리(ACTUAL + 0x1000)의 다른 부분을 읽을 수 있는지 확인하는 메시지 (실제 접근 시도).
+  msg ("memory is readable %d", *(int *) (ACTUAL + 0x1000)); // 여기서 (ACTUAL + 0x1000)는 (char*)ACTUAL + 0x1000을 의미해야 할 수 있음.
 
-  munmap (map);
+  munmap (map); // 메모리 매핑을 해제합니다.
 
+  // munmap 이후에는 해당 메모리 영역에 접근할 수 없어야 합니다.
+  // 아래 fail 호출 내에서 ACTUAL + 0x1000 주소에 접근을 시도하며, 이 접근은 오류(예: 페이지 폴트 후 종료)를 발생시켜야 합니다.
+  // 따라서 fail 메시지가 출력되지 않고 프로세스가 종료되는 것이 이 테스트의 성공 조건입니다.
   fail ("unmapped memory is readable (%d)", *(int *) (ACTUAL + 0x1000));
+  // 위와 마찬가지로 ACTUAL 주소에 접근을 시도합니다. 이 역시 오류를 발생시켜야 합니다.
   fail ("unmapped memory is readable (%d)", *(int *) (ACTUAL));
 }

--- a/tests/vm/mmap-write.c
+++ b/tests/vm/mmap-write.c
@@ -1,32 +1,43 @@
 /* Writes to a file through a mapping, and unmaps the file,
    then reads the data in the file back using the read system
    call to verify. */
+/* 매핑을 통해 파일에 쓰고, 파일을 언매핑한 다음,
+ * read 시스템 콜을 사용하여 파일의 데이터를 다시 읽어 확인합니다.*/
 
 #include <string.h>
 #include <syscall.h>
-#include "tests/vm/sample.inc"
+#include "tests/vm/sample.inc" // 'sample' 배열 (테스트용 샘플 데이터)을 포함합니다.
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define ACTUAL ((void *) 0x10000000)
+#define ACTUAL ((void *) 0x10000000) // 메모리 매핑을 위한 타겟 가상 주소입니다.
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
-  void *map;
-  char buf[1024];
+  int handle;       // 파일 핸들을 저장할 변수입니다.
+  void *map;        // mmap 호출의 반환 값(매핑된 주소)을 저장할 포인터입니다.
+  char buf[1024];   // 파일에서 데이터를 읽어올 버퍼입니다.
 
   /* Write file via mmap. */
+  // mmap을 통해 파일에 씁니다.
+  // "sample.txt"라는 이름으로 sample 데이터 길이만큼의 파일을 생성합니다. 성공 여부를 CHECK 합니다.
   CHECK (create ("sample.txt", strlen (sample)), "create \"sample.txt\"");
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // ACTUAL 주소에 "sample.txt" 파일을 4096 바이트 크기만큼, 쓰기 가능(세 번째 인자 1)으로 메모리 매핑합니다.
+  // 매핑 성공 여부(MAP_FAILED가 아닌지)를 CHECK 합니다.
   CHECK ((map = mmap (ACTUAL, 4096, 1, handle, 0)) != MAP_FAILED, "mmap \"sample.txt\"");
+  // sample 데이터를 매핑된 메모리(ACTUAL)에 복사합니다.
   memcpy (ACTUAL, sample, strlen (sample));
-  munmap (map);
+  munmap (map); // 메모리 매핑을 해제합니다. 이때 변경된 내용이 파일에 반영되어야 합니다.
 
   /* Read back via read(). */
+  // read()를 통해 다시 읽습니다.
+  // 파일 핸들(handle)을 통해 파일에서 sample 데이터 길이만큼을 buf로 읽어들입니다.
   read (handle, buf, strlen (sample));
+  // 읽어온 데이터(buf)가 원본 sample 데이터와 일치하는지 확인합니다.
   CHECK (!memcmp (buf, sample, strlen (sample)),
          "compare read data against written data");
-  close (handle);
+  close (handle); // 파일을 닫습니다.
 }

--- a/tests/vm/mmap-zero-len.c
+++ b/tests/vm/mmap-zero-len.c
@@ -1,27 +1,35 @@
-/* Tries to mmap a zero length. mmap should fail if legnth is 0. 
- * In Linux kernels before 2.6.12, mmap succeeded even with length0. 
- * In this case: no mapping was created and the call returned addr.  
- * Since kernel 2.6.12, mapping zero length fails. We expect 
+/* Tries to mmap a zero length. mmap should fail if legnth is 0.
+ * In Linux kernels before 2.6.12, mmap succeeded even with length0.
+ * In this case: no mapping was created and the call returned addr.
+ * Since kernel 2.6.12, mapping zero length fails. We expect
  * mmap in Pintos to fail (i.e. return MAP_FAILED) when length is 0. */
+/* 길이가 0인 mmap을 시도합니다. 길이가 0이면 mmap은 실패해야 합니다.
+ * 2.6.12 이전 리눅스 커널에서는 길이가 0이어도 mmap이 성공했습니다.
+ * 이 경우: 매핑이 생성되지 않았고 호출은 주소(addr)를 반환했습니다.
+ * 커널 2.6.12부터는 길이가 0인 매핑은 실패합니다. Pintos의 mmap은
+ * 길이가 0일 때 실패할 것(즉, MAP_FAILED를 반환)으로 예상합니다.*/
 
 #include <string.h>
 #include <syscall.h>
-#include "tests/vm/sample.inc"
+#include "tests/vm/sample.inc" // sample 데이터는 create 호출에 사용됩니다.
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define ACTUAL ((void *) 0x10000000)
+#define ACTUAL ((void *) 0x10000000) // 메모리 매핑을 위한 타겟 가상 주소입니다.
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
-  void *map;
+  int handle;  // 파일 핸들을 저장할 변수입니다.
+  void *map;   // mmap 호출의 반환 값을 저장할 포인터입니다.
 
-  /* Write file via mmap. */
+  /* Write file via mmap. */ // 주석은 일반적인 mmap 시나리오를 설명하지만, 여기서는 길이 0 테스트가 주 목적입니다.
+  // "sample.txt"라는 이름으로 sample 데이터 길이만큼의 파일을 생성합니다. 성공 여부를 CHECK 합니다.
   CHECK (create ("sample.txt", strlen (sample)), "create \"sample.txt\"");
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
-  CHECK ((map = mmap (ACTUAL, 0, 0, handle, 0)) == MAP_FAILED, 
+  // ACTUAL 주소에 "sample.txt" 파일을 길이 0으로, 읽기 전용(세 번째 인자 0)으로 mmap 시도합니다.
+  // 이 호출은 MAP_FAILED를 반환해야 합니다. 성공 여부를 CHECK 합니다.
+  CHECK ((map = mmap (ACTUAL, 0, 0, handle, 0)) == MAP_FAILED,
 			"try to mmap zero length");
- 
 }

--- a/tests/vm/mmap-zero.c
+++ b/tests/vm/mmap-zero.c
@@ -2,26 +2,38 @@
    should not terminate the process or crash.
    Then dereferences the address that we tried to map,
    and the process must be terminated with -1 exit code. */
+/* 길이가 0인 파일을 매핑하려고 시도합니다. 이는 작동할 수도 있고 안 할 수도 있지만
+ * 프로세스를 종료시키거나 충돌을 일으켜서는 안 됩니다.
+ * 그런 다음 매핑하려고 시도했던 주소를 역참조하며,
+ * 프로세스는 -1 종료 코드로 종료되어야 합니다.*/
 
 #include <syscall.h>
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  char *data = (char *) 0x7f000000;
-  int handle;
+  char *data = (char *) 0x7f000000; // 메모리 매핑을 시도할 타겟 가상 주소입니다.
+  int handle;                        // 파일 핸들을 저장할 변수입니다.
 
+  // "empty"라는 이름으로 길이가 0인 파일을 생성합니다. 성공 여부를 CHECK 합니다.
   CHECK (create ("empty", 0), "create empty file \"empty\"");
+  // "empty" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("empty")) > 1, "open \"empty\"");
 
   /* Calling mmap() might succeed or fail.  We don't care. */
-  msg ("mmap \"empty\"");
+  // mmap() 호출은 성공할 수도 있고 실패할 수도 있습니다. 신경 쓰지 않습니다.
+  msg ("mmap \"empty\""); // "empty" 파일에 대한 mmap 시도 메시지를 출력합니다.
+  // data 주소에 "empty" 파일을 길이 0으로, 읽기 전용(세 번째 인자 0)으로 mmap 시도합니다.
+  // 반환 값은 확인하지 않습니다.
   mmap (data, 0, 0, handle, 0);
 
   /* Regardless of whether the call worked, *data should cause
      the process to be terminated. */
+  // 호출이 작동했는지 여부에 관계없이, *data 접근은
+  // 프로세스를 종료시켜야 합니다.
+  // data 주소의 첫 바이트를 읽으려고 시도합니다. 이 접근은 오류(예: 페이지 폴트 후 종료)를 발생시켜야 합니다.
+  // 따라서 fail 메시지가 출력되지 않고 프로세스가 종료되는 것이 이 테스트의 성공 조건입니다.
   fail ("unmapped memory is readable (%d)", *data);
 }
-

--- a/tests/vm/page-linear.c
+++ b/tests/vm/page-linear.c
@@ -1,44 +1,54 @@
 /* Encrypts, then decrypts, 2 MB of memory and verifies that the
-   values are as they should be. */
+values are as they should be. */
+// (주석은 2MB를 언급하지만, 코드는 SIZE (5MB)를 사용합니다.)
+/* 5MB 크기의 메모리 버퍼를 특정 값(0x5a)으로 초기화하고, 그 내용이 올바른지 확인합니다.
+ * 그런 다음 ARC4 알고리즘을 사용하여 버퍼를 암호화하고 다시 복호화한 후,
+ * 최종적으로 버퍼의 내용이 다시 원래의 값(0x5a)으로 돌아왔는지 검증합니다.
+ * 이는 대용량 메모리 접근 및 수정을 테스트합니다. */
 
 #include <string.h>
 #include "tests/arc4.h"
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define SIZE (5 * 1024 * 1024)
+#define SIZE (5 * 1024 * 1024) // 버퍼 크기를 5MB로 정의합니다.
 
-static char buf[SIZE];
+static char buf[SIZE]; // 5MB 크기의 정적 버퍼를 선언합니다.
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  struct arc4 arc4;
-  size_t i;
+  struct arc4 arc4; // ARC4 암호화 상태를 저장할 구조체입니다.
+  size_t i;         // 반복문에서 사용할 인덱스 변수입니다.
 
   /* Initialize to 0x5a. */
-  msg ("initialize");
-  memset (buf, 0x5a, sizeof buf);
+  // 0x5a로 초기화합니다.
+  msg ("initialize"); // "initialize" 메시지를 출력합니다.
+  memset (buf, 0x5a, sizeof buf); // 버퍼 전체를 0x5a 값으로 채웁니다.
 
   /* Check that it's all 0x5a. */
-  msg ("read pass");
-  for (i = 0; i < SIZE; i++)
-    if (buf[i] != 0x5a)
-      fail ("byte %zu != 0x5a", i);
+  // 모든 내용이 0x5a인지 확인합니다.
+  msg ("read pass"); // "read pass" 메시지를 출력합니다.
+  for (i = 0; i < SIZE; i++) // 버퍼의 모든 바이트를 순회합니다.
+    if (buf[i] != 0x5a)    // 만약 해당 바이트가 0x5a가 아니면,
+      fail ("byte %zu != 0x5a", i); // 테스트 실패를 알립니다.
 
-  /* Encrypt zeros. */
-  msg ("read/modify/write pass one");
-  arc4_init (&arc4, "foobar", 6);
-  arc4_crypt (&arc4, buf, SIZE);
+  /* Encrypt zeros. */ // (주석은 "Encrypt zeros"이지만 실제로는 0x5a로 채워진 데이터를 암호화합니다.)
+  // 0x5a 데이터를 암호화합니다.
+  msg ("read/modify/write pass one"); // "read/modify/write pass one" 메시지를 출력합니다.
+  arc4_init (&arc4, "foobar", 6);   // ARC4 구조체를 "foobar" 키로 초기화합니다.
+  arc4_crypt (&arc4, buf, SIZE);    // buf의 내용을 SIZE만큼 암호화합니다.
 
-  /* Decrypt back to zeros. */
-  msg ("read/modify/write pass two");
-  arc4_init (&arc4, "foobar", 6);
-  arc4_crypt (&arc4, buf, SIZE);
+  /* Decrypt back to zeros. */ // (주석은 "Decrypt back to zeros"이지만 실제로는 0x5a로 복호화합니다.)
+  // 다시 0x5a로 복호화합니다.
+  msg ("read/modify/write pass two"); // "read/modify/write pass two" 메시지를 출력합니다.
+  arc4_init (&arc4, "foobar", 6);   // ARC4 구조체를 동일한 키로 다시 초기화합니다.
+  arc4_crypt (&arc4, buf, SIZE);    // 암호화된 buf의 내용을 SIZE만큼 복호화합니다.
 
   /* Check that it's all 0x5a. */
-  msg ("read pass");
-  for (i = 0; i < SIZE; i++)
-    if (buf[i] != 0x5a)
-      fail ("byte %zu != 0x5a", i);
+  // 모든 내용이 다시 0x5a인지 확인합니다.
+  msg ("read pass"); // "read pass" 메시지를 출력합니다.
+  for (i = 0; i < SIZE; i++) // 버퍼의 모든 바이트를 순회합니다.
+    if (buf[i] != 0x5a)    // 만약 해당 바이트가 0x5a가 아니면,
+      fail ("byte %zu != 0x5a", i); // 테스트 실패를 알립니다.
 }

--- a/tests/vm/page-merge-mm.c
+++ b/tests/vm/page-merge-mm.c
@@ -1,8 +1,12 @@
+/* parallel_merge라는 유틸리티 함수를 호출하여 병렬 정렬 및 병합 테스트를 수행합니다.
+ * child-qsort-mm (메모리 매핑을 사용하여 퀵 정렬하는 자식 프로세스)를 자식 프로세스로 사용하며,
+ * 자식 프로세스의 예상 종료 코드는 80입니다. */
+
 #include "tests/main.h"
 #include "tests/vm/parallel-merge.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   parallel_merge ("child-qsort-mm", 80);
 }

--- a/tests/vm/page-merge-par.c
+++ b/tests/vm/page-merge-par.c
@@ -1,8 +1,11 @@
+/*  parallel_merge라는 유틸리티 함수를 호출하여 병렬 정렬 및 병합 테스트를 수행합니다.
+ *  child-sort (계수 정렬하는 자식 프로세스)를 자식 프로세스로 사용하며,
+ *  자식 프로세스의 예상 종료 코드는 123입니다. */
 #include "tests/main.h"
-#include "tests/vm/parallel-merge.h"
+#include "tests/vm/parallel-merge.h" // parallel_merge 함수를 포함합니다.
 
 void
-test_main (void) 
+test_main (void)
 {
   parallel_merge ("child-sort", 123);
 }

--- a/tests/vm/page-merge-seq.c
+++ b/tests/vm/page-merge-seq.c
@@ -2,6 +2,10 @@
    16 chunks.  A separate subprocess sorts each chunk in
    sequence.  Then we merge the chunks and verify that the result
    is what it should be. */
+/* 약 1MB의 랜덤 데이터를 생성하여 16개의 청크로 나눕니다.
+ * 각 청크는 별도의 자식 프로세스(child-sort)에 의해 순차적으로 정렬됩니다.
+ * 그 후, 부모 프로세스는 정렬된 청크들을 병합하고 최종 결과가 올바른지
+ * (원래 데이터의 모든 요소가 정렬된 순서로 포함되어 있는지) 확인합니다. */
 
 #include <syscall.h>
 #include "tests/arc4.h"
@@ -11,142 +15,168 @@
 /* This is the max file size for an older version of the Pintos
    file system that had 126 direct blocks each pointing to a
    single disk sector.  We could raise it now. */
-#define CHUNK_SIZE (126 * 512)
-#define CHUNK_CNT 16                            /* Number of chunks. */
-#define DATA_SIZE (CHUNK_CNT * CHUNK_SIZE)      /* Buffer size. */
+// 이것은 각 디스크 섹터를 가리키는 126개의 직접 블록을 가졌던
+// 이전 버전 Pintos 파일 시스템의 최대 파일 크기입니다. 지금은 늘릴 수 있습니다.
+#define CHUNK_SIZE (126 * 512)                  // 청크 크기를 정의합니다 (126 * 512 바이트).
+#define CHUNK_CNT 16                            /* Number of chunks. */ // 청크의 수 (16개).
+#define DATA_SIZE (CHUNK_CNT * CHUNK_SIZE)      /* Buffer size. */    // 전체 데이터 버퍼 크기 (16 * CHUNK_SIZE).
 
-unsigned char buf1[DATA_SIZE], buf2[DATA_SIZE];
-size_t histogram[256];
+unsigned char buf1[DATA_SIZE], buf2[DATA_SIZE]; // 원본/정렬된 청크용 버퍼(buf1)와 최종 병합된 결과용 버퍼(buf2)를 선언합니다.
+size_t histogram[256];                          // 데이터의 바이트 값 빈도수를 저장할 히스토그램입니다.
 
 /* Initialize buf1 with random data,
    then count the number of instances of each value within it. */
+// buf1을 랜덤 데이터로 초기화한 다음,
+// 그 안의 각 값의 발생 횟수를 셉니다.
 static void
-init (void)
+init (void) // 데이터 초기화 함수입니다.
 {
-  struct arc4 arc4;
-  size_t i;
+  struct arc4 arc4; // ARC4 암호화(여기서는 랜덤 데이터 생성용) 상태 구조체입니다.
+  size_t i;         // 반복문 인덱스입니다.
 
-  msg ("init");
+  msg ("init"); // "init" 메시지를 출력합니다.
 
-  arc4_init (&arc4, "foobar", 6);
-  arc4_crypt (&arc4, buf1, sizeof buf1);
-  for (i = 0; i < sizeof buf1; i++)
-    histogram[buf1[i]]++;
+  arc4_init (&arc4, "foobar", 6);      // ARC4를 "foobar" 키로 초기화합니다.
+  arc4_crypt (&arc4, buf1, sizeof buf1); // buf1을 ARC4로 암호화하여 랜덤 데이터처럼 만듭니다.
+  for (i = 0; i < sizeof buf1; i++)   // buf1의 모든 바이트를 순회합니다.
+    histogram[buf1[i]]++;             // 각 바이트 값의 빈도수를 히스토그램에 기록합니다 (검증용).
 }
 
 /* Sort each chunk of buf1 using a subprocess. */
+// 하위 프로세스를 사용하여 buf1의 각 청크를 정렬합니다.
 static void
-sort_chunks (void)
+sort_chunks (void) // 청크 정렬 함수입니다.
 {
-  size_t i;
+  size_t i; // 반복문 인덱스입니다.
 
-  create ("buffer", CHUNK_SIZE);
-  for (i = 0; i < CHUNK_CNT; i++)
+  create ("buffer", CHUNK_SIZE); // 자식 프로세스가 사용할 임시 파일 "buffer"를 CHUNK_SIZE로 생성합니다.
+  for (i = 0; i < CHUNK_CNT; i++) // 각 청크에 대해 반복합니다.
     {
-      pid_t child;
-      int handle;
+      pid_t child; // 자식 프로세스 ID를 저장할 변수입니다.
+      int handle;  // 파일 핸들을 저장할 변수입니다.
 
-      msg ("sort chunk %zu", i);
+      msg ("sort chunk %zu", i); // 현재 정렬할 청크 번호를 출력합니다.
 
       /* Write this chunk to a file. */
-      quiet = true;
+      // 이 청크를 파일에 씁니다.
+      quiet = true; // 메시지 출력을 잠시 억제합니다.
+      // "buffer" 파일을 엽니다. 성공 여부를 CHECK 합니다.
       CHECK ((handle = open ("buffer")) > 1, "open \"buffer\"");
+      // 현재 청크(buf1 + CHUNK_SIZE * i)를 "buffer" 파일에 씁니다.
       write (handle, buf1 + CHUNK_SIZE * i, CHUNK_SIZE);
-      close (handle);
+      close (handle); // 파일을 닫습니다.
 
       /* Sort with subprocess. */
-      child = fork("child-sort");
-			/* if (child == 0) { */
-			/* 	CHECK (exec ("child-sort buffer") != -1, "exec \"child-sort buffer\""); */
-			/* } else { */
-			/* 	CHECK (wait (child) == 123, "wait for child-sort"); */
-			if (child == 0) {
-				quiet = false;
-				msg ("child[%zu] exec", i);
+      // 하위 프로세스로 정렬합니다.
+      child = fork("child-sort"); // "child-sort"라는 이름으로 자식 프로세스를 fork 합니다.
+      // 아래는 자식/부모 프로세스 분기입니다.
+			if (child == 0) { // 자식 프로세스인 경우
+				quiet = false; // 자식 프로세스 메시지 출력을 활성화합니다.
+				msg ("child[%zu] exec", i); // 자식 실행 메시지를 출력합니다.
+        // "child-sort buffer"를 실행하여 "buffer" 파일 내용을 정렬합니다.
 				if (exec ("child-sort buffer") == -1)
-					fail ("child[%zu] exec fail", i);
-				quiet = true;
-			} else {
-				quiet = false;
+					fail ("child[%zu] exec fail", i); // exec 실패 시 테스트 실패를 알립니다.
+				quiet = true; // 자식 프로세스 메시지 출력을 다시 억제합니다. (실제로는 exec 후 실행 안됨)
+			} else { // 부모 프로세스인 경우
+				quiet = false; // 부모 프로세스 메시지 출력을 활성화합니다.
+        // 자식 프로세스가 종료될 때까지 기다립니다. 종료 코드가 123인지 확인합니다.
 				if (wait (child) != 123)
-					fail ("child[%zu] wait fail", i);
-				msg ("child[%zu] wait success", i);
-				quiet = true;
+					fail ("child[%zu] wait fail", i); // 예상 종료 코드가 아니면 테스트 실패를 알립니다.
+				msg ("child[%zu] wait success", i); // 자식 대기 성공 메시지를 출력합니다.
+				quiet = true; // 부모 프로세스 메시지 출력을 다시 억제합니다.
 
 				/* Read chunk back from file. */
+        // 파일에서 정렬된 청크를 다시 읽습니다.
+        // "buffer" 파일을 다시 엽니다. 성공 여부를 CHECK 합니다.
 				CHECK ((handle = open ("buffer")) > 1, "open \"buffer\"");
+        // 정렬된 파일 내용을 원래 청크 위치(buf1 + CHUNK_SIZE * i)로 다시 읽어들입니다.
 				read (handle, buf1 + CHUNK_SIZE * i, CHUNK_SIZE);
-				close (handle);
+				close (handle); // 파일을 닫습니다.
 
-				quiet = false;
+				quiet = false; // 부모 프로세스 메시지 출력을 다시 활성화합니다. (다음 반복을 위해)
 			}
     }
 }
 
 /* Merge the sorted chunks in buf1 into a fully sorted buf2. */
+// buf1의 정렬된 청크들을 완전히 정렬된 buf2로 병합합니다.
 static void
-merge (void)
+merge (void) // 병합 함수입니다.
 {
+  // 각 청크의 현재 병합 위치를 가리키는 포인터 배열입니다.
   unsigned char *mp[CHUNK_CNT];
-  size_t mp_left;
-  unsigned char *op;
-  size_t i;
+  size_t mp_left;             // 아직 병합할 데이터가 남은 청크의 수입니다.
+  unsigned char *op;          // buf2에 데이터를 쓸 위치를 가리키는 포인터입니다.
+  size_t i;                   // 반복문 인덱스입니다.
 
-  msg ("merge");
+  msg ("merge"); // "merge" 메시지를 출력합니다.
 
   /* Initialize merge pointers. */
-  mp_left = CHUNK_CNT;
-  for (i = 0; i < CHUNK_CNT; i++)
-    mp[i] = buf1 + CHUNK_SIZE * i;
+  // 병합 포인터를 초기화합니다.
+  mp_left = CHUNK_CNT; // 남은 청크 수를 초기화합니다.
+  for (i = 0; i < CHUNK_CNT; i++) // 각 청크에 대해
+    mp[i] = buf1 + CHUNK_SIZE * i; // 해당 청크의 시작 주소로 포인터를 설정합니다.
 
   /* Merge. */
-  op = buf2;
-  while (mp_left > 0)
+  // 병합합니다.
+  op = buf2; // 출력 포인터를 buf2의 시작으로 설정합니다.
+  while (mp_left > 0) // 병합할 청크가 남아있는 동안 반복합니다.
     {
       /* Find smallest value. */
-      size_t min = 0;
+      // 가장 작은 값을 찾습니다.
+      size_t min = 0; // 가장 작은 값을 가진 청크의 인덱스를 저장합니다.
+      // 현재 남아있는 청크들 중에서 (mp[0] ~ mp[mp_left-1])
       for (i = 1; i < mp_left; i++)
-        if (*mp[i] < *mp[min])
-          min = i;
+        if (*mp[i] < *mp[min]) // 현재 최소값보다 더 작은 값을 찾으면
+          min = i;             // min 인덱스를 갱신합니다.
 
       /* Append value to buf2. */
+      // 찾은 가장 작은 값을 buf2에 추가합니다.
       *op++ = *mp[min];
 
       /* Advance merge pointer.
          Delete this chunk from the set if it's emptied. */
-      if ((++mp[min] - buf1) % CHUNK_SIZE == 0)
-        mp[min] = mp[--mp_left];
+      // 병합 포인터를 진행시킵니다.
+      // 이 청크가 비워졌으면 집합에서 삭제합니다.
+      // 해당 청크의 포인터(mp[min])를 1 증가시키고,
+      if ((++mp[min] - buf1) % CHUNK_SIZE == 0) // 만약 해당 청크의 끝에 도달했다면
+        mp[min] = mp[--mp_left]; // 해당 청크를 유효한 마지막 청크로 대체하고 남은 청크 수를 줄입니다.
     }
 }
 
+// 최종 정렬된 결과(buf2)가 올바른지(원래 데이터의 히스토그램과 일치하는지) 확인합니다.
 static void
-verify (void)
+verify (void) // 검증 함수입니다.
 {
-  size_t buf_idx;
-  size_t hist_idx;
+  size_t buf_idx;  // buf2를 순회하기 위한 인덱스입니다.
+  size_t hist_idx; // 히스토그램을 순회하기 위한 인덱스입니다 (0-255 바이트 값).
 
-  msg ("verify");
+  msg ("verify"); // "verify" 메시지를 출력합니다.
 
-  buf_idx = 0;
+  buf_idx = 0; // buf2 인덱스를 0으로 초기화합니다.
+  // 히스토그램의 모든 바이트 값(0부터 255까지)에 대해 반복합니다.
   for (hist_idx = 0; hist_idx < sizeof histogram / sizeof *histogram;
        hist_idx++)
     {
+      // 현재 바이트 값(hist_idx)이 원래 데이터에 있었던 횟수(histogram[hist_idx])만큼 반복합니다.
       while (histogram[hist_idx]-- > 0)
         {
+          // buf2의 현재 위치(buf_idx)에 있는 값이 예상되는 바이트 값(hist_idx)과 다르면
           if (buf2[buf_idx] != hist_idx)
-            fail ("bad value %d in byte %zu", buf2[buf_idx], buf_idx);
-          buf_idx++;
+            fail ("bad value %d in byte %zu", buf2[buf_idx], buf_idx); // 테스트 실패를 알립니다.
+          buf_idx++; // buf2 인덱스를 증가시킵니다.
         }
     }
 
+  // 모든 검증이 통과하고 buf_idx가 원래 데이터 크기와 같으면 성공입니다.
   msg ("success, buf_idx=%'zu", buf_idx);
 }
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  init ();
-  sort_chunks ();
-  merge ();
-  verify ();
+  init ();        // 데이터 초기화 함수를 호출합니다.
+  sort_chunks (); // 청크 정렬 함수를 호출합니다.
+  merge ();       // 병합 함수를 호출합니다.
+  verify ();      // 검증 함수를 호출합니다.
 }

--- a/tests/vm/page-merge-stk.c
+++ b/tests/vm/page-merge-stk.c
@@ -1,8 +1,11 @@
+/* parallel_merge라는 유틸리티 함수를 호출하여 병렬 정렬 및 병합 테스트를 수행합니다.
+ * child-qsort (스택 기반 버퍼를 사용하여 퀵 정렬하는 자식 프로세스)를 자식 프로세스로 사용하며,
+ * 자식 프로세스의 예상 종료 코드는 72입니다. */
 #include "tests/main.h"
 #include "tests/vm/parallel-merge.h"
 
 void
-test_main (void) 
+test_main (void)
 {
   parallel_merge ("child-qsort", 72);
 }

--- a/tests/vm/page-parallel.c
+++ b/tests/vm/page-parallel.c
@@ -1,25 +1,32 @@
 /* Runs 4 child-linear processes at once. */
+/* child-linear라는 자식 프로세스 4개를 동시에 실행하고,
+ * 각 자식 프로세스가 성공적으로 완료(종료 코드 0x42 반환)될 때까지 기다립니다.
+ * 이는 여러 프로세스가 병렬로 메모리 작업을 수행하는 상황을 시뮬레이션합니다. */
 
 #include <syscall.h>
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define CHILD_CNT 4
+#define CHILD_CNT 4 // 실행할 자식 프로세스의 수를 4로 정의합니다.
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  pid_t children[CHILD_CNT];
-  int i;
+  pid_t children[CHILD_CNT]; // 자식 프로세스들의 ID를 저장할 배열입니다.
+  int i;                     // 반복문에서 사용할 인덱스 변수입니다.
 
+  // CHILD_CNT 만큼 반복하여 자식 프로세스를 생성하고 실행합니다.
   for (i = 0; i < CHILD_CNT; i++) {
-    children[i] = fork ("child-linear");
-    if (children[i] == 0) {
+    children[i] = fork ("child-linear"); // "child-linear"라는 이름으로 자식 프로세스를 fork 합니다.
+    if (children[i] == 0) { // 자식 프로세스인 경우
+      // "child-linear"를 실행합니다. exec 호출이 실패하면 (-1 반환)
       if (exec ("child-linear") == -1)
-        fail ("failed to exec child-linear");
+        fail ("failed to exec child-linear"); // 테스트 실패를 알립니다.
     }
   }
+  // 모든 자식 프로세스가 종료될 때까지 기다립니다.
   for (i = 0; i < CHILD_CNT; i++) {
+    // i번째 자식 프로세스(children[i])를 기다리고, 반환된 종료 코드가 0x42인지 확인합니다.
     CHECK (wait (children[i]) == 0x42, "wait for child %d", i);
   }
 }

--- a/tests/vm/page-shuffle.c
+++ b/tests/vm/page-shuffle.c
@@ -1,5 +1,7 @@
 /* Shuffles a 128 kB data buffer 10 times, printing the checksum
-   after each time. */
+after each time. */
+// 128KB 데이터 버퍼를 10번 섞고, 매번 그 후의
+// 체크섬을 출력합니다.
 
 #include <stdbool.h>
 #include "tests/arc4.h"
@@ -7,24 +9,29 @@
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define SIZE (128 * 1024)
+#define SIZE (128 * 1024) // 버퍼 크기를 128KB로 정의합니다.
 
-static char buf[SIZE];
+static char buf[SIZE]; // 128KB 크기의 정적 버퍼를 선언합니다.
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  size_t i;
+  size_t i; // 반복문에서 사용할 인덱스 변수입니다.
 
   /* Initialize. */
-  for (i = 0; i < sizeof buf; i++)
-    buf[i] = i * 257;
+  // 초기화합니다.
+  for (i = 0; i < sizeof buf; i++) // 버퍼의 모든 바이트를 순회합니다.
+    buf[i] = i * 257;             // 각 바이트를 i * 257 값으로 초기화합니다. (데이터 패턴 생성)
+  // 초기화된 데이터의 체크섬을 계산하고 "init: cksum=값" 형식으로 메시지를 출력합니다.
   msg ("init: cksum=%lu", cksum (buf, sizeof buf));
-    
+
   /* Shuffle repeatedly. */
-  for (i = 0; i < 10; i++)
-    {
-      shuffle (buf, sizeof buf, 1);
-      msg ("shuffle %zu: cksum=%lu", i, cksum (buf, sizeof buf));
-    }
+  // 반복적으로 섞습니다.
+  for (i = 0; i < 10; i++) // 10번 반복합니다.
+  {
+    // 버퍼(buf)의 데이터를 섞습니다. (세 번째 인자 1은 섞는 강도 또는 횟수를 의미할 수 있음)
+    shuffle (buf, sizeof buf, 1);
+    // 섞인 후 데이터의 체크섬을 계산하고 "shuffle 인덱스: cksum=값" 형식으로 메시지를 출력합니다.
+    msg ("shuffle %zu: cksum=%lu", i, cksum (buf, sizeof buf));
+  }
 }

--- a/tests/vm/parallel-merge.c
+++ b/tests/vm/parallel-merge.c
@@ -2,150 +2,109 @@
    16 chunks.  A separate subprocess sorts each chunk; the
    subprocesses run in parallel.  Then we merge the chunks and
    verify that the result is what it should be. */
+/* parallel_merge라는 핵심 함수를 제공하며, 이 함수는 약 1MB의 랜덤 데이터를 생성하여 여러 청크로 나눕니다.
+ * 각 청크는 별도의 자식 프로세스에 의해 병렬로 정렬됩니다.
+ * 그 후, 부모 프로세스는 정렬된 청크들을 병합하고 최종 결과가 올바른지
+ * (원래 데이터의 모든 요소가 정렬된 순서로 포함되어 있는지) 확인합니다.
+ * 이 파일 자체는 parallel_merge 함수의 구현부이며, 다른 page-merge-xx.c  테스트 파일들이
+ * 이 함수를 호출하여 특정 자식 프로세스(정렬 방식)와 예상 종료 코드를 지정하여 테스트를 실행합니다*/
+// (주석은 16 청크를 언급하지만, 아래 CHUNK_CNT는 8로 정의됨)
 
-#include "tests/vm/parallel-merge.h"
+#include "tests/vm/parallel-merge.h" // 이 파일에서 제공하는 parallel_merge 함수의 선언을 포함합니다.
 #include <stdio.h>
 #include <syscall.h>
 #include "tests/arc4.h"
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define CHUNK_SIZE (128 * 1024)
-#define CHUNK_CNT 8                             /* Number of chunks. */
-#define DATA_SIZE (CHUNK_CNT * CHUNK_SIZE)      /* Buffer size. */
+#define CHUNK_SIZE (128 * 1024)                 // 각 청크의 크기를 128KB로 정의합니다.
+#define CHUNK_CNT 8                             /* Number of chunks. */ // 청크의 수를 8로 정의합니다.
+#define DATA_SIZE (CHUNK_CNT * CHUNK_SIZE)      /* Buffer size. */    // 전체 데이터 버퍼 크기를 계산합니다 (8 * 128KB = 1MB).
 
-unsigned char buf1[DATA_SIZE], buf2[DATA_SIZE];
-size_t histogram[256];
+unsigned char buf1[DATA_SIZE], buf2[DATA_SIZE]; // 원본/정렬된 청크용 버퍼(buf1)와 최종 병합된 결과용 버퍼(buf2)를 선언합니다.
+size_t histogram[256];                          // 데이터의 바이트 값 빈도수를 저장할 히스토그램입니다 (검증용).
 
 /* Initialize buf1 with random data,
    then count the number of instances of each value within it. */
+// buf1을 랜덤 데이터로 초기화한 다음,
+// 그 안의 각 값의 발생 횟수를 셉니다.
 static void
-init (void)
+init (void) // 데이터 초기화 함수입니다.
 {
-  struct arc4 arc4;
-  size_t i;
+  struct arc4 arc4; // ARC4 암호화(여기서는 랜덤 데이터 생성용) 상태 구조체입니다.
+  size_t i;         // 반복문 인덱스입니다.
 
-  msg ("init");
+  msg ("init"); // "init" 메시지를 출력합니다.
 
-  arc4_init (&arc4, "foobar", 6);
-  arc4_crypt (&arc4, buf1, sizeof buf1);
-  for (i = 0; i < sizeof buf1; i++)
-    histogram[buf1[i]]++;
+  arc4_init (&arc4, "foobar", 6);      // ARC4를 "foobar" 키로 초기화합니다.
+  arc4_crypt (&arc4, buf1, sizeof buf1); // buf1을 ARC4로 암호화하여 랜덤 데이터처럼 만듭니다.
+  for (i = 0; i < sizeof buf1; i++)   // buf1의 모든 바이트를 순회합니다.
+    histogram[buf1[i]]++;             // 각 바이트 값의 빈도수를 히스토그램에 기록합니다.
 }
 
 /* Sort each chunk of buf1 using SUBPROCESS,
    which is expected to return EXIT_STATUS. */
+// SUBPROCESS를 사용하여 buf1의 각 청크를 정렬하며,
+// SUBPROCESS는 EXIT_STATUS를 반환할 것으로 예상됩니다.
 static void
-sort_chunks (const char *subprocess, int exit_status)
+sort_chunks (const char *subprocess, int exit_status) // 청크 정렬 함수입니다. 자식 프로세스 이름과 예상 종료 코드를 인자로 받습니다.
 {
-  pid_t children[CHUNK_CNT];
-  size_t i;
+  pid_t children[CHUNK_CNT]; // 자식 프로세스들의 ID를 저장할 배열입니다.
+  size_t i;                  // 반복문 인덱스입니다.
 
-  for (i = 0; i < CHUNK_CNT; i++)
+  for (i = 0; i < CHUNK_CNT; i++) // 각 청크에 대해 반복합니다.
     {
-      char fn[128];
-      char cmd[128];
-      int handle;
+      char fn[128];  // 각 청크 데이터를 저장할 파일 이름을 만들 버퍼입니다.
+      char cmd[128]; // 자식 프로세스 실행 명령 문자열을 만들 버퍼입니다.
+      int handle;    // 파일 핸들을 저장할 변수입니다.
 
-      msg ("sort chunk %zu", i);
+      msg ("sort chunk %zu", i); // 현재 정렬할 청크 번호를 출력합니다.
 
       /* Write this chunk to a file. */
-      snprintf (fn, sizeof fn, "buf%zu", i);
-      create (fn, CHUNK_SIZE);
-      quiet = true;
-      CHECK ((handle = open (fn)) > 1, "open \"%s\"", fn);
+      // 이 청크를 파일에 씁니다.
+      snprintf (fn, sizeof fn, "buf%zu", i); // 파일 이름을 "buf0", "buf1", ... 형식으로 만듭니다.
+      create (fn, CHUNK_SIZE);                // 해당 이름으로 청크 크기만큼의 파일을 생성합니다.
+      quiet = true; // 메시지 출력을 잠시 억제합니다.
+      CHECK ((handle = open (fn)) > 1, "open \"%s\"", fn); // 생성된 파일을 엽니다.
+      // 현재 청크(buf1 + CHUNK_SIZE * i)를 해당 파일에 씁니다.
       write (handle, buf1 + CHUNK_SIZE * i, CHUNK_SIZE);
-      close (handle);
+      close (handle); // 파일을 닫습니다.
 
       /* Sort with subprocess. */
-      snprintf (cmd, sizeof cmd, "%s %s", subprocess, fn);
-      children[i] = fork (subprocess);
-      if (children[i] == 0)
+      // 하위 프로세스로 정렬합니다.
+      snprintf (cmd, sizeof cmd, "%s %s", subprocess, fn); // 실행할 명령 문자열을 만듭니다 (예: "child-sort buf0").
+      children[i] = fork (subprocess); // `subprocess` 이름으로 fork하여 자식 프로세스 ID를 저장합니다.
+      if (children[i] == 0) // 자식 프로세스인 경우
+        // 만들어진 명령(cmd)으로 자식 프로세스를 실행(exec)합니다. exec 실패 여부를 CHECK 합니다.
         CHECK ((children[i] = exec (cmd)) != -1, "exec \"%s\"", cmd);
-      quiet = false;
+      quiet = false; // 부모 프로세스에서 메시지 출력을 다시 활성화합니다.
     }
 
-  for (i = 0; i < CHUNK_CNT; i++)
+  for (i = 0; i < CHUNK_CNT; i++) // 모든 자식 프로세스에 대해 반복합니다.
     {
-      char fn[128];
-      int handle;
+      char fn[128]; // 파일 이름을 만들 버퍼입니다.
+      int handle;   // 파일 핸들을 저장할 변수입니다.
 
+      // i번째 자식 프로세스(children[i])가 종료될 때까지 기다리고, 반환된 종료 코드가 exit_status와 같은지 CHECK 합니다.
       CHECK (wait (children[i]) == exit_status, "wait for child %zu", i);
 
       /* Read chunk back from file. */
-      quiet = true;
-      snprintf (fn, sizeof fn, "buf%zu", i);
-      CHECK ((handle = open (fn)) > 1, "open \"%s\"", fn);
+      // 파일에서 정렬된 청크를 다시 읽습니다.
+      quiet = true; // 메시지 출력을 잠시 억제합니다.
+      snprintf (fn, sizeof fn, "buf%zu", i); // 파일 이름을 다시 만듭니다.
+      CHECK ((handle = open (fn)) > 1, "open \"%s\"", fn); // 파일을 엽니다.
+      // 정렬된 파일 내용을 원래 청크 위치(buf1 + CHUNK_SIZE * i)로 다시 읽어들입니다.
       read (handle, buf1 + CHUNK_SIZE * i, CHUNK_SIZE);
-      close (handle);
-      quiet = false;
+      close (handle); // 파일을 닫습니다.
+      quiet = false; // 메시지 출력을 다시 활성화합니다.
     }
 }
 
 /* Merge the sorted chunks in buf1 into a fully sorted buf2. */
+// buf1의 정렬된 청크들을 완전히 정렬된 buf2로 병합합니다.
 static void
-merge (void)
+merge (void) // 병합 함수입니다.
 {
-  unsigned char *mp[CHUNK_CNT];
-  size_t mp_left;
-  unsigned char *op;
-  size_t i;
-
-  msg ("merge");
-
-  /* Initialize merge pointers. */
-  mp_left = CHUNK_CNT;
-  for (i = 0; i < CHUNK_CNT; i++)
-    mp[i] = buf1 + CHUNK_SIZE * i;
-
-  /* Merge. */
-  op = buf2;
-  while (mp_left > 0)
-    {
-      /* Find smallest value. */
-      size_t min = 0;
-      for (i = 1; i < mp_left; i++)
-        if (*mp[i] < *mp[min])
-          min = i;
-
-      /* Append value to buf2. */
-      *op++ = *mp[min];
-
-      /* Advance merge pointer.
-         Delete this chunk from the set if it's emptied. */
-      if ((++mp[min] - buf1) % CHUNK_SIZE == 0)
-        mp[min] = mp[--mp_left];
-    }
-}
-
-static void
-verify (void)
-{
-  size_t buf_idx;
-  size_t hist_idx;
-
-  msg ("verify");
-
-  buf_idx = 0;
-  for (hist_idx = 0; hist_idx < sizeof histogram / sizeof *histogram;
-       hist_idx++)
-    {
-      while (histogram[hist_idx]-- > 0)
-        {
-          if (buf2[buf_idx] != hist_idx)
-            fail ("bad value %d in byte %zu", buf2[buf_idx], buf_idx);
-          buf_idx++;
-        }
-    }
-
-  msg ("success, buf_idx=%'zu", buf_idx);
-}
-
-void
-parallel_merge (const char *child_name, int exit_status)
-{
-  init ();
-  sort_chunks (child_name, exit_status);
-  merge ();
-  verify ();
-}
+  unsigned char *mp[CHUNK_CNT]; // 각 청크의 현재 병합 위치를 가리키는 포인터 배열입니다.
+  size_t mp_left;               // 아직 병합할 데이터가 남은 청크의 수입니다.
+  unsigned char *op;            // buf2에 데이터를 쓸 위치를 가리

--- a/tests/vm/pt-bad-addr.c
+++ b/tests/vm/pt-bad-addr.c
@@ -1,11 +1,17 @@
 /* Accesses a bad address.
    The process must be terminated with -1 exit code. */
+/* 유효하지 않은 메모리 주소(0x04000000)에 접근(읽기)을 시도합니다.
+ * 이 접근 시도는 실패해야 하며, 프로세스는 -1 종료 코드로 종료되어야 합니다. */
 
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
+  // 0x04000000 주소에서 정수 값을 읽으려고 시도합니다.
+  // 이 주소는 일반적으로 유효하지 않은(매핑되지 않은) 주소이므로, 이 접근은 페이지 폴트를 유발하고
+  // 커널에 의해 프로세스가 비정상 종료(-1)되어야 합니다.
+  // 따라서 fail 메시지가 실제로 출력되지 않고 프로세스가 종료되는 것이 성공입니다.
   fail ("bad addr read as %d", *(int *) 0x04000000);
 }

--- a/tests/vm/pt-bad-read.c
+++ b/tests/vm/pt-bad-read.c
@@ -1,16 +1,23 @@
 /* Reads from a file into a bad address.
    The process must be terminated with -1 exit code. */
+/* 열려 있는 파일("sample.txt")에서 데이터를 읽어들이되,
+ * 읽어들인 데이터를 저장할 버퍼 주소로 유효하지 않은 주소(스택 포인터에서 4096바이트 떨어진 주소)를 지정합니다.
+ * 이 read 시스템 콜은 실패해야 하며, 프로세스는 -1 종료 코드로 종료되어야 합니다. */
 
 #include <syscall.h>
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
+  int handle; // 파일 핸들을 저장할 변수입니다.
 
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // 파일(handle)에서 1 바이트를 읽어, 현재 스택의 지역 변수 handle 주소로부터 4096 바이트 이전의 주소에 저장하려고 시도합니다.
+  // 이 주소는 유효하지 않은 주소일 가능성이 높으므로, 이 read 호출은 실패하거나 프로세스를 종료시켜야 합니다.
   read (handle, (char *) &handle - 4096, 1);
+  // 만약 read 호출 이후에도 프로그램이 계속 실행된다면, 테스트는 실패한 것입니다.
   fail ("survived reading data into bad address");
 }

--- a/tests/vm/pt-big-stk-obj.c
+++ b/tests/vm/pt-big-stk-obj.c
@@ -1,5 +1,7 @@
 /* Allocates and writes to a 64 kB object on the stack.
    This must succeed. */
+/* 스택에 64KB 크기의 큰 객체(배열)를 할당하고 해당 객체에 데이터를 씁니다.
+ * 이 작업은 성공적으로 수행되어야 하며, 이는 스택이 필요에 따라 충분히 확장될 수 있음을 테스트합니다. */
 
 #include <string.h>
 #include "tests/arc4.h"
@@ -8,13 +10,15 @@
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  char stk_obj[65536];
-  struct arc4 arc4;
+  char stk_obj[65536]; // 스택에 64KB (65536 바이트) 크기의 배열을 선언합니다.
+  struct arc4 arc4;    // ARC4 암호화(여기서는 데이터 패턴 생성용) 상태 구조체입니다.
 
-  arc4_init (&arc4, "foobar", 6);
-  memset (stk_obj, 0, sizeof stk_obj);
-  arc4_crypt (&arc4, stk_obj, sizeof stk_obj);
+  arc4_init (&arc4, "foobar", 6);     // ARC4를 "foobar" 키로 초기화합니다.
+  memset (stk_obj, 0, sizeof stk_obj); // 스택 객체(stk_obj)를 0으로 초기화합니다.
+  arc4_crypt (&arc4, stk_obj, sizeof stk_obj); // ARC4로 stk_obj의 내용을 암호화(변형)합니다.
+  // stk_obj의 체크섬을 계산하고 "cksum: 값" 형식으로 메시지를 출력합니다.
+  // 이 과정에서 스택 확장이 필요하면 제대로 이루어져야 합니다.
   msg ("cksum: %lu", cksum (stk_obj, sizeof stk_obj));
 }

--- a/tests/vm/pt-grow-bad.c
+++ b/tests/vm/pt-grow-bad.c
@@ -1,14 +1,21 @@
 /* Read from an address 4,096 bytes below the stack pointer.
    The process must be terminated with -1 exit code. */
+/* 현재 스택 포인터(rsp)보다 4096바이트 아래 주소에서 데이터를 읽으려고 시도합니다.
+ * 스택은 일반적으로 아래로(낮은 주소로) 자라지만, 한 번에 너무 큰 간격으로 접근하거나
+ * 아직 할당되지 않은 영역에 접근하면 실패해야 합니다.
+ * 이 경우, 프로세스는 -1 종료 코드로 종료되어야 합니다. */
 
 #include <string.h>
-#include "tests/arc4.h"
-#include "tests/cksum.h"
+#include "tests/arc4.h"  // 이 파일에서 직접 사용되지 않으나, 유사한 테스트 파일들과의 일관성을 위해 포함될 수 있음.
+#include "tests/cksum.h" // 이 파일에서 직접 사용되지 않으나, 유사한 테스트 파일들과의 일관성을 위해 포함될 수 있음.
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
+  // 인라인 어셈블리를 사용하여 현재 스택 포인터(rsp)에서 4096을 뺀 주소의 내용을 rax 레지스터로 이동(읽기)하려고 시도합니다.
+  // 이 주소는 일반적으로 아직 할당되지 않은 스택 영역이거나 접근 권한이 없는 영역일 수 있으므로,
+  // 이 접근은 페이지 폴트를 유발하고 커널에 의해 프로세스가 비정상 종료(-1)되어야 합니다.
   asm volatile ("movq -4096(%rsp), %rax");
 }

--- a/tests/vm/pt-grow-stack.c
+++ b/tests/vm/pt-grow-stack.c
@@ -1,6 +1,9 @@
 /* Demonstrate that the stack can grow.
    This must succeed. */
-
+/* 스택이 필요에 따라 증가할 수 있음을 보여줍니다.
+ * 스택에 4KB 크기의 객체를 할당하고 데이터를 쓴 후 체크섬을 계산합니다.
+ * 이 과정은 반드시 성공적으로 완료되어야 하며,
+ * 이는 스택이 해당 크기만큼 정상적으로 확장되었음을 의미합니다. */
 #include <string.h>
 #include "tests/arc4.h"
 #include "tests/cksum.h"
@@ -8,13 +11,15 @@
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  char stack_obj[4096];
-  struct arc4 arc4;
+  char stack_obj[4096]; // 스택에 4KB (4096 바이트) 크기의 배열을 선언합니다.
+  struct arc4 arc4;     // ARC4 암호화(여기서는 데이터 패턴 생성용) 상태 구조체입니다.
 
-  arc4_init (&arc4, "foobar", 6);
-  memset (stack_obj, 0, sizeof stack_obj);
-  arc4_crypt (&arc4, stack_obj, sizeof stack_obj);
+  arc4_init (&arc4, "foobar", 6);        // ARC4를 "foobar" 키로 초기화합니다.
+  memset (stack_obj, 0, sizeof stack_obj); // 스택 객체(stack_obj)를 0으로 초기화합니다.
+  arc4_crypt (&arc4, stack_obj, sizeof stack_obj); // ARC4로 stack_obj의 내용을 암호화(변형)합니다.
+  // stack_obj의 체크섬을 계산하고 "cksum: 값" 형식으로 메시지를 출력합니다.
+  // 이 과정에서 스택 공간이 할당(필요시 확장)되어야 합니다.
   msg ("cksum: %lu", cksum (stack_obj, sizeof stack_obj));
 }

--- a/tests/vm/pt-grow-stk-sc.c
+++ b/tests/vm/pt-grow-stk-sc.c
@@ -3,30 +3,43 @@
    call.
 
    From Godmar Back. */
+/* 스택 위치에 대한 첫 번째 접근이 시스템 콜 내부에서 발생하더라도 스택이 올바르게 확장되는지 확인합니다.
+ * 파일을 생성하고 데이터를 쓴 다음, 그 파일을 다시 열어서 스택의 특정 깊은 위치에 있는 버퍼로 파일 내용을 읽어들입니다.
+ * 이 read 시스템 콜 시점에 해당 스택 영역이 유효하게 확장되어야 합니다.*/
 
 #include <string.h>
 #include <syscall.h>
-#include "tests/vm/sample.inc"
+#include "tests/vm/sample.inc" // 'sample' 배열 (테스트용 샘플 데이터)을 포함합니다.
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
-  int slen = strlen (sample);
+  int handle;              // 파일 핸들을 저장할 변수입니다.
+  int slen = strlen (sample); // sample 데이터의 길이를 저장합니다.
+  // 스택에 64KB 크기의 버퍼를 선언합니다. 이 버퍼의 특정 위치에 시스템 콜을 통해 접근할 것입니다.
   char buf2[65536];
 
   /* Write file via write(). */
+  // write()를 통해 파일에 씁니다.
+  // "sample.txt"라는 이름으로 slen 길이만큼의 파일을 생성합니다. 성공 여부를 CHECK 합니다.
   CHECK (create ("sample.txt", slen), "create \"sample.txt\"");
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // sample 데이터를 파일에 씁니다. 쓰여진 바이트 수가 slen과 같은지 CHECK 합니다.
   CHECK (write (handle, sample, slen) == slen, "write \"sample.txt\"");
-  close (handle);
+  close (handle); // 파일을 닫습니다.
 
   /* Read back via read(). */
+  // read()를 통해 다시 읽습니다.
+  // "sample.txt" 파일을 다시 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "2nd open \"sample.txt\"");
+  // 파일 내용을 buf2 배열의 중간 지점(buf2 + 32768)부터 slen 길이만큼 읽어들입니다.
+  // 이 read 시스템 콜 시점에 buf2 + 32768 주소에 해당하는 스택 페이지가 유효하게 확장되어야 합니다.
   CHECK (read (handle, buf2 + 32768, slen) == slen, "read \"sample.txt\"");
 
+  // 읽어들인 데이터(buf2 + 32768)가 원본 sample 데이터와 일치하는지 확인합니다.
   CHECK (!memcmp (sample, buf2 + 32768, slen), "compare written data against read data");
-  close (handle);
+  close (handle); // 파일을 닫습니다.
 }

--- a/tests/vm/pt-write-code.c
+++ b/tests/vm/pt-write-code.c
@@ -1,12 +1,17 @@
 /* Try to write to the code segment.
    The process must be terminated with -1 exit code. */
-
+/* 프로그램의 코드 세그먼트(실행 가능한 명령어들이 있는 메모리 영역)에 직접 쓰기를 시도합니다.
+ * 이 작업은 실패해야 하며, 프로세스는 -1 종료 코드로 종료되어야 합니다. */
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
+  // 현재 실행 중인 test_main 함수의 시작 주소(코드 세그먼트)에 정수 0을 쓰려고 시도합니다.
+  // 이 작업은 메모리 보호 위반으로 인해 페이지 폴트를 유발하고,
+  // 커널에 의해 프로세스가 비정상 종료(-1)되어야 합니다.
   *(int *) test_main = 0;
+  // 만약 위의 쓰기 작업 이후에도 프로그램이 계속 실행된다면, 테스트는 실패한 것입니다.
   fail ("writing the code segment succeeded");
 }

--- a/tests/vm/pt-write-code2.c
+++ b/tests/vm/pt-write-code2.c
@@ -1,15 +1,21 @@
 /* Try to write to the code segment using a system call.
    The process must be terminated with -1 exit code. */
-
+/* 시스템 콜(read)을 사용하여 프로그램의 코드 세그먼트에 데이터를 쓰려고 시도합니다.
+ * 열려 있는 파일("sample.txt")의 내용을 코드 세그먼트 주소(test_main 함수의 시작 주소)로 읽어들이려고 합니다.
+ * 이 작업은 실패해야 하며, 프로세스는 -1 종료 코드로 종료되어야 합니다 */
 #include "tests/lib.h"
 #include "tests/main.h"
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  int handle;
+  int handle; // 파일 핸들을 저장할 변수입니다.
 
+  // "sample.txt" 파일을 엽니다. 성공 여부를 CHECK 합니다.
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
+  // 파일(handle)에서 1 바이트를 읽어, test_main 함수의 시작 주소(코드 세그먼트)에 저장하려고 시도합니다.
+  // 이 작업은 메모리 보호 위반으로 인해 시스템 콜이 실패하거나 프로세스가 종료되어야 합니다.
   read (handle, (void *) test_main, 1);
+  // 만약 read 호출 이후에도 프로그램이 계속 실행된다면, 테스트는 실패한 것입니다.
   fail ("survived reading data into code segment");
 }

--- a/tests/vm/qsort.c
+++ b/tests/vm/qsort.c
@@ -1,13 +1,19 @@
-#include "tests/vm/qsort.h"
+/* qsort_bytes라는 바이트 배열을 위한 퀵 정렬(quick-sort) 알고리즘 구현을 제공합니다.
+ * 실제 테스트 케이스라기보다는 다른 테스트(child-qsort.c, child-qsort-mm.c 등)에서
+ * 사용되는 유틸리티 함수들의 모음입니다. 주요 기능은 피벗 선택, 파티셔닝, 정렬 여부 확인, 바이트 스왑 등입니다. */
+
+#include "tests/vm/qsort.h" // 이 파일에서 제공하는 함수의 선언을 포함합니다 (qsort_bytes).
 #include <stdbool.h>
 #include <debug.h>
 #include <random.h>
 
 /* Picks a pivot for the quicksort from the SIZE bytes in BUF. */
+// BUF 내의 SIZE 바이트 중에서 퀵정렬을 위한 피벗을 선택합니다.
 static unsigned char
-pick_pivot (unsigned char *buf, size_t size) 
+pick_pivot (unsigned char *buf, size_t size) // 피벗 선택 함수입니다.
 {
-  ASSERT (size >= 1);
+  ASSERT (size >= 1); // 배열 크기가 최소 1 이상이어야 함을 단언합니다.
+  // 랜덤하게 선택된 인덱스의 바이트 값을 피벗으로 반환합니다.
   return buf[random_ulong () % size];
 }
 
@@ -15,122 +21,139 @@ pick_pivot (unsigned char *buf, size_t size)
    initial LEFT_SIZE elements all less than PIVOT followed by
    SIZE - LEFT_SIZE elements all greater than or equal to
    PIVOT. */
+// ARRAY 내의 SIZE 바이트가 PIVOT보다 작은 초기 LEFT_SIZE 개의 요소들과
+// 그 뒤에 PIVOT보다 크거나 같은 SIZE - LEFT_SIZE 개의 요소들로
+// 나누어져 있는지 확인합니다.
 static bool
 is_partitioned (const unsigned char *array, size_t size,
-                unsigned char pivot, size_t left_size) 
+                unsigned char pivot, size_t left_size) // 파티션 검증 함수입니다.
 {
-  size_t i;
-  
+  size_t i; // 반복문 인덱스입니다.
+
+  // 왼쪽 부분(0 ~ left_size-1)의 모든 요소가 pivot보다 작은지 확인합니다.
   for (i = 0; i < left_size; i++)
-    if (array[i] >= pivot)
+    if (array[i] >= pivot) // pivot보다 크거나 같은 요소가 발견되면 false를 반환합니다.
       return false;
 
+  // 오른쪽 부분(left_size ~ size-1)의 모든 요소가 pivot보다 크거나 같은지 확인합니다.
   for (; i < size; i++)
-    if (array[i] < pivot)
+    if (array[i] < pivot) // pivot보다 작은 요소가 발견되면 false를 반환합니다.
       return false;
 
-  return true;
+  return true; // 모든 조건 만족 시 true를 반환합니다.
 }
 
 /* Swaps the bytes at *A and *B. */
+// *A와 *B 위치의 바이트를 교환합니다.
 static void
-swap (unsigned char *a, unsigned char *b) 
+swap (unsigned char *a, unsigned char *b) // 두 바이트 값을 교환하는 함수입니다.
 {
-  unsigned char t = *a;
-  *a = *b;
-  *b = t;
+  unsigned char t = *a; // 임시 변수 t에 a의 값을 저장합니다.
+  *a = *b;              // a에 b의 값을 저장합니다.
+  *b = t;               // b에 원래 a의 값(t)을 저장합니다.
 }
 
 /* Partitions ARRAY in-place in an initial run of bytes all less
    than PIVOT, followed by a run of bytes all greater than or
    equal to PIVOT.  Returns the length of the initial run. */
+// ARRAY를 PIVOT보다 작은 바이트들의 초기 실행 부분과
+// 그 뒤에 PIVOT보다 크거나 같은 바이트들의 실행 부분으로 제자리에서 분할합니다.
+// 초기 실행 부분의 길이를 반환합니다.
 static size_t
-partition (unsigned char *array, size_t size, int pivot) 
+partition (unsigned char *array, size_t size, int pivot) // 배열 파티셔닝 함수입니다.
 {
-  size_t left_size = size;
-  unsigned char *first = array;
-  unsigned char *last = first + left_size;
+  size_t left_size = size; // 왼쪽 부분의 크기를 일단 전체 크기로 초기화합니다. (실제로는 pivot보다 작은 요소들의 개수)
+  unsigned char *first = array;          // 배열의 시작을 가리키는 포인터입니다.
+  unsigned char *last = first + left_size; // 배열의 끝 다음을 가리키는 포인터입니다. (실제로는 오른쪽 부분의 시작)
 
-  for (;;)
+  for (;;) // 무한 루프 (탈출 조건은 내부에서 처리)
     {
       /* Move FIRST forward to point to first element greater than
          PIVOT. */
-      for (;;)
+      // FIRST를 PIVOT보다 큰 첫 번째 요소를 가리키도록 앞으로 이동시킵니다.
+      for (;;) // 내부 루프
         {
-          if (first == last)
+          if (first == last) // first와 last가 만나면 (모든 요소 검사 완료)
             {
-              ASSERT (is_partitioned (array, size, pivot, left_size));
-              return left_size;
+              ASSERT (is_partitioned (array, size, pivot, left_size)); // 파티션이 올바르게 되었는지 단언합니다.
+              return left_size; // 왼쪽 부분의 크기를 반환합니다.
             }
-          else if (*first >= pivot)
-            break;
+          else if (*first >= pivot) // first가 가리키는 값이 pivot보다 크거나 같으면
+            break;                  // 내부 루프를 탈출합니다.
 
-          first++;
+          first++; // first 포인터를 다음 요소로 이동합니다.
         }
-      left_size--;
+      left_size--; // pivot보다 크거나 같은 요소를 찾았으므로, left_size를 하나 줄입니다. (해당 요소는 왼쪽 부분에 속하지 않음)
 
       /* Move LAST backward to point to last element no bigger
          than PIVOT. */
-      for (;;)
+      // LAST를 PIVOT보다 크지 않은(작거나 같은) 마지막 요소를 가리키도록 뒤로 이동시킵니다.
+      for (;;) // 내부 루프
         {
-          last--;
+          last--; // last 포인터를 이전 요소로 이동합니다.
 
-          if (first == last)
+          if (first == last) // first와 last가 만나면
             {
-              ASSERT (is_partitioned (array, size, pivot, left_size));
-              return left_size;
+              ASSERT (is_partitioned (array, size, pivot, left_size)); // 파티션이 올바르게 되었는지 단언합니다.
+              return left_size; // 왼쪽 부분의 크기를 반환합니다.
             }
-          else if (*last < pivot)
-            break;
-          else
-            left_size--;
+          else if (*last < pivot) // last가 가리키는 값이 pivot보다 작으면
+            break;                // 내부 루프를 탈출합니다.
+          else // last가 가리키는 값이 pivot보다 크거나 같으면 (오른쪽 부분에 속함)
+            left_size--; // left_size를 하나 줄입니다. (해당 요소는 왼쪽 부분에 속하지 않음)
         }
 
       /* By swapping FIRST and LAST we extend the starting and
          ending sequences that pass and fail, respectively,
          PREDICATE. */
-      swap (first, last);
-      first++;
+      // FIRST와 LAST를 교환함으로써, 각각 PREDICATE를 통과하고 실패하는
+      // 시작 및 종료 시퀀스를 확장합니다. (즉, pivot보다 작은 값을 왼쪽으로, 큰 값을 오른쪽으로 보냄)
+      swap (first, last); // first와 last가 가리키는 값을 교환합니다.
+      first++;            // first 포인터를 다음 요소로 이동합니다.
     }
 }
 
 /* Returns true if the SIZE bytes in BUF are in nondecreasing
    order, false otherwise. */
+// BUF 내의 SIZE 바이트가 비감소 순서(오름차순)이면 true를, 그렇지 않으면 false를 반환합니다.
 static bool
-is_sorted (const unsigned char *buf, size_t size) 
+is_sorted (const unsigned char *buf, size_t size) // 정렬 여부 확인 함수입니다.
 {
-  size_t i;
+  size_t i; // 반복문 인덱스입니다.
 
+  // 배열의 두 번째 요소부터 마지막 요소까지 순회합니다.
   for (i = 1; i < size; i++)
-    if (buf[i - 1] > buf[i])
-      return false;
+    if (buf[i - 1] > buf[i]) // 이전 요소가 현재 요소보다 크면 (정렬되지 않음)
+      return false;          // false를 반환합니다.
 
-  return true;
+  return true; // 모든 요소가 정렬되어 있으면 true를 반환합니다.
 }
 
 /* Sorts the SIZE bytes in BUF into nondecreasing order, using
    the quick-sort algorithm. */
+// 퀵정렬 알고리즘을 사용하여 BUF 내의 SIZE 바이트를 비감소 순서로 정렬합니다.
 void
-qsort_bytes (unsigned char *buf, size_t size) 
+qsort_bytes (unsigned char *buf, size_t size) // 바이트 배열 퀵정렬 함수입니다.
 {
-  if (!is_sorted (buf, size)) 
+  if (!is_sorted (buf, size)) // 배열이 이미 정렬되어 있지 않다면 (정렬할 필요가 있다면)
     {
-      int pivot = pick_pivot (buf, size);
+      int pivot = pick_pivot (buf, size); // 피벗을 선택합니다.
 
-      unsigned char *left_half = buf;
-      size_t left_size = partition (buf, size, pivot);
-      unsigned char *right_half = left_half + left_size;
-      size_t right_size = size - left_size;
-  
-      if (left_size <= right_size) 
+      unsigned char *left_half = buf;                // 왼쪽 부분 배열의 시작 포인터입니다.
+      size_t left_size = partition (buf, size, pivot); // 배열을 피벗 기준으로 파티셔닝하고 왼쪽 부분의 크기를 얻습니다.
+      unsigned char *right_half = left_half + left_size; // 오른쪽 부분 배열의 시작 포인터입니다.
+      size_t right_size = size - left_size;            // 오른쪽 부분의 크기입니다.
+
+      // 더 작은 부분 배열을 먼저 재귀적으로 정렬하여 스택 깊이를 줄이려는 시도입니다.
+      if (left_size <= right_size)
         {
-          qsort_bytes (left_half, left_size);
-          qsort_bytes (right_half, right_size); 
+          qsort_bytes (left_half, left_size);   // 왼쪽 부분을 재귀적으로 정렬합니다.
+          qsort_bytes (right_half, right_size); // 오른쪽 부분을 재귀적으로 정렬합니다.
         }
       else
         {
-          qsort_bytes (right_half, right_size); 
-          qsort_bytes (left_half, left_size);
+          qsort_bytes (right_half, right_size); // 오른쪽 부분을 재귀적으로 정렬합니다.
+          qsort_bytes (left_half, left_size);   // 왼쪽 부분을 재귀적으로 정렬합니다.
         }
-    } 
+    }
 }

--- a/tests/vm/swap-anon.c
+++ b/tests/vm/swap-anon.c
@@ -5,6 +5,13 @@
  * does some write operations on each chunk, 
  * then check if the data is consistent
  * Lastly, frees the allocated memory. */
+// 익명 페이지가
+// 제대로 스왑 아웃되고 스왑 인 되는지 확인합니다.
+// 이 테스트를 위해 Pintos 메모리 크기는 10MB입니다.
+// 먼저 큰 메모리 청크를 할당하고,
+// 각 청크에 쓰기 작업을 수행한 다음,
+// 데이터가 일관성이 있는지 확인합니다.
+// 마지막으로 할당된 메모리를 해제합니다.
 
 #include <string.h>
 #include <stdint.h>
@@ -13,35 +20,39 @@
 #include "tests/main.h"
 
 
-#define PAGE_SHIFT 12
-#define PAGE_SIZE (1 << PAGE_SHIFT)
-#define ONE_MB (1 << 20) // 1MB
-#define CHUNK_SIZE (20*ONE_MB)
-#define PAGE_COUNT (CHUNK_SIZE / PAGE_SIZE)
+#define PAGE_SHIFT 12                // 페이지 크기를 위한 시프트 값 (2^12 = 4096)
+#define PAGE_SIZE (1 << PAGE_SHIFT)  // 페이지 크기 (4KB)
+#define ONE_MB (1 << 20)             // 1MB 크기
+#define CHUNK_SIZE (20*ONE_MB)       // 테스트에서 사용할 전체 메모리 청크 크기 (20MB)
+#define PAGE_COUNT (CHUNK_SIZE / PAGE_SIZE) // 청크 내 총 페이지 수 (20MB / 4KB = 5120 페이지)
 
-static char big_chunks[CHUNK_SIZE];
+static char big_chunks[CHUNK_SIZE]; // 20MB 크기의 정적 데이터 배열입니다. 익명 페이지로 취급됩니다.
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
-	size_t i;
-    void* pa;
-    char *mem;
+	size_t i;    // 반복문 인덱스 변수입니다.
+    // void* pa;    // 이 변수는 코드에서 사용되지 않습니다.
+    char *mem;   // 메모리 특정 위치를 가리킬 포인터입니다.
 
+    // CHUNK_SIZE (20MB) 만큼의 메모리 영역을 페이지 단위로 순회하며 값을 씁니다.
+    // 메모리 크기가 10MB로 제한되어 있으므로, 이 과정에서 스왑 아웃이 발생해야 합니다.
     for (i = 0 ; i < PAGE_COUNT ; i++) {
-        if(!(i % 512))
+        if(!(i % 512)) // 512 페이지마다 (약 2MB 간격) 메시지를 출력합니다.
             msg ("write sparsely over page %zu", i);
-        mem = (big_chunks+(i*PAGE_SIZE));
-        *mem = (char)i;
+        mem = (big_chunks+(i*PAGE_SIZE)); // 현재 페이지의 시작 주소를 계산합니다.
+        *mem = (char)i;                   // 해당 페이지의 첫 바이트에 페이지 번호(i)의 하위 바이트를 저장합니다.
     }
 
+    // 다시 메모리 영역을 페이지 단위로 순회하며 값을 읽고 확인합니다.
+    // 스왑 아웃된 페이지는 이 과정에서 다시 스왑 인 되어야 합니다.
     for (i = 0 ; i < PAGE_COUNT ; i++) {
-        mem = (big_chunks+(i*PAGE_SIZE));
-        if((char)i != *mem) {
-		    fail ("data is inconsistent");
+        mem = (big_chunks+(i*PAGE_SIZE)); // 현재 페이지의 시작 주소를 계산합니다.
+        if((char)i != *mem) {             // 이전에 저장한 값과 현재 읽은 값이 다르면,
+		    fail ("data is inconsistent");  // 데이터 불일치로 테스트 실패를 알립니다.
         }
-        if(!(i % 512))
+        if(!(i % 512)) // 512 페이지마다 메시지를 출력합니다.
             msg ("check consistency in page %zu", i);
     }
+    // 명시적인 메모리 해제는 없으며, 프로세스 종료 시 OS가 정리합니다.
 }
-

--- a/tests/vm/swap-file.c
+++ b/tests/vm/swap-file.c
@@ -3,6 +3,11 @@
  * For this test, Pintos memory size is 128MB 
  * First, fills the memory with with anonymous pages
  * and then tries to map a file into the page */
+/* 파일 매핑된 페이지(file-mapped pages)가 제대로 스왑 아웃(swap out) 및 스왑 인(swap in) 되는지 확인합니다.
+ * Pintos 메모리 크기가 128MB로 설정된 환경에서 테스트합니다.
+ * 먼저 메모리를 익명 페이지로 채운 다음 (주석에는 그렇게 되어 있지만, 코드에서는
+ * 이 부분이 명시적으로 구현되어 있지 않고 바로 파일 매핑을 시도합니다),
+ * 파일을 페이지에 매핑하고 데이터 일관성을 확인합니다. */
 
 #include <string.h>
 #include <syscall.h>
@@ -10,38 +15,49 @@
 #include <stdint.h>
 #include "tests/lib.h"
 #include "tests/main.h"
-#include "tests/vm/large.inc"
+#include "tests/vm/large.inc" // 'large' 배열 (테스트용 대용량 데이터)을 포함합니다.
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
-    size_t handle;
-    char *actual = (char *) 0x10000000;
-    void *map;
-    size_t i;
+    size_t handle; // 파일 핸들을 저장할 변수입니다.
+    char *actual = (char *) 0x10000000; // 메모리 매핑을 위한 타겟 가상 주소입니다.
+    void *map;     // mmap 호출의 반환 값(매핑된 주소)을 저장할 포인터입니다.
+    size_t i;      // 반복문 인덱스 변수입니다.
 
     /* Map a page to a file */
+    // 페이지를 파일에 매핑합니다.
+    // "large.txt" 파일을 엽니다. (large.txt는 large 데이터로 미리 만들어져 있어야 함)
+    // 성공 여부를 CHECK 합니다.
     CHECK ((handle = open ("large.txt")) > 1, "open \"large.txt\"");
+    // actual 주소에 "large.txt" 파일을 large 데이터 전체 크기만큼, 읽기 전용(세 번째 인자 0)으로 메모리 매핑합니다.
+    // 매핑 성공 여부(MAP_FAILED가 아닌지)를 CHECK 합니다.
     CHECK ((map = mmap (actual, sizeof(large), 0, handle, 0)) != MAP_FAILED, "mmap \"large.txt\"");
 
     /* Check that data is correct. */
+    // 데이터가 올바른지 확인합니다.
+    // 매핑된 메모리(actual)의 내용이 원본 large 데이터와 (large 데이터의 문자열 길이만큼) 일치하는지 확인합니다.
     if (memcmp (actual, large, strlen (large)))
-        fail ("read of mmap'd file reported bad data");
+        fail ("read of mmap'd file reported bad data"); // 일치하지 않으면 테스트 실패를 알립니다.
 
     /* Verify that data is followed by zeros. */
-    size_t len = strlen(large);
-    size_t page_end;
-    for(page_end = 0; page_end < len; page_end+=4096);
+    // 데이터 뒤에 0이 오는지 확인합니다. (파일 크기가 페이지 크기의 배수가 아닐 경우, 나머지 부분은 0으로 채워짐)
+    size_t len = strlen(large); // large 데이터의 실제 문자열 길이를 가져옵니다.
+    size_t page_end;            // 파일 내용이 끝나는 지점 다음의 첫 페이지 경계 오프셋을 계산하기 위한 변수입니다.
+    // len을 포함하는 마지막 페이지의 끝 오프셋을 계산합니다.
+    for(page_end = 0; page_end < len; page_end+=4096); // page_end는 len 이상인 최소 4096의 배수가 됩니다.
 
-    for (i = len+1; i < page_end; i++) 
+    // 실제 파일 내용(len) 다음부터 해당 내용이 포함된 마지막 페이지의 끝(page_end)까지를 순회합니다.
+    for (i = len+1; i < page_end; i++)
     {
-        if (actual[i] != 0) {
+        if (actual[i] != 0) { // 해당 바이트가 0이 아니면 (페이지의 나머지 부분이 0으로 채워지지 않음)
+            // 오류 메시지를 출력하고 테스트 실패를 알립니다.
             fail ("byte %zu of mmap'd region has value %02hhx (should be 0)", i, actual[i]);
         }
     }
 
-    /* Unmap and close opend file */ 
-    munmap (map);
-    close (handle);
+    /* Unmap and close opend file */
+    // 매핑을 해제하고 열린 파일을 닫습니다.
+    munmap (map);   // 메모리 매핑을 해제합니다.
+    close (handle); // 파일을 닫습니다.
 }
-

--- a/tests/vm/swap-fork.c
+++ b/tests/vm/swap-fork.c
@@ -1,31 +1,37 @@
-/* */
+/* child-swap이라는 자식 프로세스를 여러 개(CHILD_CNT 만큼, 여기서는 10개) 생성(fork)하고 실행(exec)합니다.
+ * 각 자식 프로세스는 메모리 할당 및 접근을 통해 스왑 기능을 테스트할 것으로 예상됩니다 (이름으로 유추).
+ * 부모 프로세스는 모든 자식 프로세스가 성공적으로 종료(종료 코드 0 반환)될 때까지 기다립니다.
+ * 하나라도 다른 코드로 종료되면, 스택 손상 등의 문제를 의심하며 테스트를 실패시킵니다 */
 
 #include <string.h>
 #include <syscall.h>
 #include <stdio.h>
 #include "tests/lib.h"
 #include "tests/main.h"
-#include "tests/vm/large.inc"
+#include "tests/vm/large.inc" // large 데이터는 이 파일에서 직접 사용되지 않습니다.
 
-#define CHILD_CNT 10
+#define CHILD_CNT 10 // 생성할 자식 프로세스의 수를 10으로 정의합니다.
 
 void
-test_main (void) 
+test_main (void) // 테스트의 메인 함수입니다.
 {
-  pid_t child[CHILD_CNT];
-  size_t i;
-  
+	pid_t child[CHILD_CNT]; // 자식 프로세스들의 ID를 저장할 배열입니다.
+	size_t i;               // 반복문 인덱스 변수입니다.
+
 	/* Spawn children */
-    for(i =0; i < CHILD_CNT; i++) {
-	  child[i] = fork("child-swap");
-	  if (child[i] == 0) {
-	  	if(exec ("child-swap") == -1)
-            fail("exec \"child-swap\"");
-	  }
-    }
+	// 자식들을 생성합니다.
+	for(i =0; i < CHILD_CNT; i++) { // CHILD_CNT 만큼 반복합니다.
+		child[i] = fork("child-swap"); // "child-swap"라는 이름으로 자식 프로세스를 fork하고 PID를 저장합니다.
+		if (child[i] == 0) { // 자식 프로세스인 경우
+			if(exec ("child-swap") == -1) // "child-swap"을 실행(exec)합니다. exec이 -1을 반환하면 (실패하면)
+				fail("exec \"child-swap\""); // 테스트 실패를 알립니다.
+		}
+	}
 	/* Wait for children */
-    for(i =0; i < CHILD_CNT; i++) {
-  	  if(wait (child[i]) != 0)
-          fail("More than one child process' stack is corrupted");
-    }
+	// 자식들을 기다립니다.
+	for(i =0; i < CHILD_CNT; i++) { // CHILD_CNT 만큼 반복합니다.
+		if(wait (child[i]) != 0) // i번째 자식 프로세스가 종료될 때까지 기다리고, 반환된 종료 코드가 0이 아니면
+			// 하나 이상의 자식 프로세스 스택이 손상되었다고 가정하고 테스트 실패를 알립니다.
+				fail("More than one child process' stack is corrupted");
+	}
 }

--- a/tests/vm/swap-iter.c
+++ b/tests/vm/swap-iter.c
@@ -1,57 +1,75 @@
 /* Checks if any type of memory is properly swapped out and swapped in 
  * For this test, Pintos memory size is 128MB */ 
+/* 다양한 유형의 메모리(익명 페이지와 파일 매핑 페이지)가 제대로 스왑 아웃 및 스왑 인 되는지를 반복적으로 확인합니다.
+ * Pintos 메모리 크기가 128MB로 설정된 환경에서 테스트합니다.
+ * 먼저 큰 익명 페이지 청크에 데이터를 쓰고, 파일을 메모리에 매핑하여 읽습니다.
+ * 그 다음 다시 익명 페이지의 데이터를 확인하고, 마지막으로 파일 매핑 페이지의 데이터를 다시 확인합니다.
+ * 이 과정에서 메모리 부족으로 스왑이 발생했을 때 데이터 일관성이 유지되는지를 검증합니다. */
 
 #include <string.h>
 #include <syscall.h>
 #include <stdio.h>
 #include "tests/lib.h"
 #include "tests/main.h"
-#include "tests/vm/large.inc"
+#include "tests/vm/large.inc" // 'large' 배열 (테스트용 대용량 데이터)을 포함합니다.
 
 
-#define PAGE_SHIFT 12
-#define PAGE_SIZE (1 << PAGE_SHIFT)
-#define ONE_MB (1 << 20) // 1MB
-#define CHUNK_SIZE (20*ONE_MB)
-#define PAGE_COUNT (CHUNK_SIZE / PAGE_SIZE)
+#define PAGE_SHIFT 12                // 페이지 크기를 위한 시프트 값 (2^12 = 4096)
+#define PAGE_SIZE (1 << PAGE_SHIFT)  // 페이지 크기 (4KB)
+#define ONE_MB (1 << 20)             // 1MB 크기
+#define CHUNK_SIZE (20*ONE_MB)       // 익명 페이지로 사용할 전체 메모리 청크 크기 (20MB)
+#define PAGE_COUNT (CHUNK_SIZE / PAGE_SIZE) // 익명 페이지 청크 내 총 페이지 수 (20MB / 4KB = 5120 페이지)
 
-static char big_chunks[CHUNK_SIZE];
+static char big_chunks[CHUNK_SIZE]; // 20MB 크기의 정적 데이터 배열 (익명 페이지용).
 
 void
-test_main (void)
+test_main (void) // 테스트의 메인 함수입니다.
 {
-    size_t i, handle;
-    char *actual = (char *) 0x10000000;
-    void *map;
+    size_t i, handle;                 // i는 반복문 인덱스, handle은 파일 핸들입니다.
+    char *actual = (char *) 0x10000000; // 파일 매핑을 위한 타겟 가상 주소입니다.
+    void *map;                        // mmap 호출의 반환 값(매핑된 주소)을 저장할 포인터입니다.
 
+    // 익명 페이지(big_chunks)에 희소하게(sparsely) 값을 씁니다.
+    // 메모리 압박 상황을 만들기 위해 많은 페이지에 접근합니다.
     for (i = 0 ; i < PAGE_COUNT ; i++) {
-        if ((i & 0x1ff) == 0)
+        if ((i & 0x1ff) == 0) // 512 페이지마다 (0x1ff == 511) 메시지를 출력합니다.
             msg ("write sparsely over page %zu", i);
-        big_chunks[i*PAGE_SIZE] = (char) i;
+        big_chunks[i*PAGE_SIZE] = (char) i; // 각 페이지의 첫 바이트에 페이지 번호(i)의 하위 바이트를 저장합니다.
     }
 
+    // "large.txt" 파일을 엽니다. (large.txt는 large 데이터로 미리 만들어져 있어야 함)
+    // 성공 여부를 CHECK 합니다.
     CHECK ((handle = open ("large.txt")) > 1, "open \"large.txt\"");
+    // actual 주소에 "large.txt" 파일을 large 데이터 전체 크기만큼, 읽기 전용(세 번째 인자 0)으로 메모리 매핑합니다.
+    // 매핑 성공 여부(MAP_FAILED가 아닌지)를 CHECK 합니다.
     CHECK ((map = mmap (actual, sizeof(large), 0, handle, 0)) != MAP_FAILED, "mmap \"large.txt\"");
 
     /* Read in file map'd page */
+    // 파일 매핑된 페이지를 읽습니다.
+    // 매핑된 메모리(actual)의 내용이 원본 large 데이터와 (large 데이터의 문자열 길이만큼) 일치하는지 확인합니다.
     if (memcmp (actual, large, strlen (large)))
-        fail ("read of mmap'd file reported bad data");
+        fail ("read of mmap'd file reported bad data"); // 일치하지 않으면 테스트 실패를 알립니다.
 
 
     /* Read in anon page */
+    // 익명 페이지를 읽습니다.
+    // 이전에 썼던 익명 페이지(big_chunks)의 내용을 다시 확인합니다.
+    // 스왑 아웃/인 후에도 데이터가 유지되는지 검사합니다.
     for (i = 0; i < PAGE_COUNT; i++) {
-        if (big_chunks[i*PAGE_SIZE] != (char) i)
-            fail ("data is inconsistent");
-        if ((i & 0x1ff) == 0)
+        if (big_chunks[i*PAGE_SIZE] != (char) i) // 저장했던 값과 현재 읽은 값이 다르면,
+            fail ("data is inconsistent");          // 데이터 불일치로 테스트 실패를 알립니다.
+        if ((i & 0x1ff) == 0) // 512 페이지마다 메시지를 출력합니다.
             msg ("check consistency in page %zu", i);
     }
 
     /* Check file map'd page again */
+    // 파일 매핑된 페이지를 다시 확인합니다.
+    // 익명 페이지 접근 후에도 파일 매핑된 페이지의 내용이 여전히 올바른지 다시 확인합니다.
     if (memcmp (actual, large, strlen (large)))
-        fail ("read of mmap'd file reported bad data");
+        fail ("read of mmap'd file reported bad data"); // 일치하지 않으면 테스트 실패를 알립니다.
 
     /* Unmap and close opend file */
-    munmap (map);
-    close (handle);
+    // 매핑을 해제하고 열린 파일을 닫습니다.
+    munmap (map);   // 메모리 매핑을 해제합니다.
+    close (handle); // 파일을 닫습니다.
 }
-

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -4,14 +4,14 @@
 #include "devices/disk.h"
 
 /* DO NOT MODIFY BELOW LINE */
-// ※ 해당 라인은 수정하지마세요. ※
+/* 아래 라인은 수정하지 말 것 */
 static struct disk *swap_disk;
 static bool anon_swap_in (struct page *page, void *kva);
 static bool anon_swap_out (struct page *page);
 static void anon_destroy (struct page *page);
 
 /* DO NOT MODIFY this struct */
-// ※ 해당 구조체는 수정하지 마세요. ※
+/* 아래 구조체는 수정하지 말 것 */
 static const struct page_operations anon_ops = {
 	.swap_in = anon_swap_in,
 	.swap_out = anon_swap_out,
@@ -20,40 +20,41 @@ static const struct page_operations anon_ops = {
 };
 
 /* Initialize the data for anonymous pages */
-// 익명 페이지에 대한 데이터 초기화를 수행합니다.
+/* 익명 페이지에 대한 데이터 초기화 수행 */
 void
 vm_anon_init (void) {
 	/* TODO: Set up the swap_disk. */
-	// swao_disk를 설정하세요.
+	/* TODO: swap_disk 셋업 */
 	swap_disk = NULL;
 }
 
 /* Initialize the file mapping */
-// 파일 매핑을 초기화합니다.
+/* 파일 매핑을 초기화 */
 bool
 anon_initializer (struct page *page, enum vm_type type, void *kva) {
 	/* Set up the handler */
-	// handler를 설정하세요.
+	/* 핸들러 셋업 */
 	page->operations = &anon_ops;
 
 	struct anon_page *anon_page = &page->anon;
 }
 
 /* Swap in the page by read contents from the swap disk. */
+/* 스왑 디스크로부터 내용을 읽어 페이지를 swap in */
 static bool
 anon_swap_in (struct page *page, void *kva) {
 	struct anon_page *anon_page = &page->anon;
 }
 
 /* Swap out the page by writing contents to the swap disk. */
-// 스왑 디스크에서 내용을 읽어 페이지를 스왑합니다.
+/* 스왑 디스크로 써넣은 페이지를 swap out */
 static bool
 anon_swap_out (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */
-// 익명 페이지를 삭제합니다. 호출자가 PAGE를 해제합니다.
+/* 익명 페이지를 파기. 호출자에 의해 페이지가 free됨. */
 static void
 anon_destroy (struct page *page) {
 	struct anon_page *anon_page = &page->anon;

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -1,9 +1,10 @@
 /* vm.c: Generic interface for virtual memory objects. */
 /* vm.c: 가상 메모리 객체를 위한 일반 인터페이스. */
-
+#define VM // thread 구조체 내부 defif VM의 spt에 접근하기 위한 선언 (vm.c는 VM으로 동작)
 #include "threads/malloc.h"
 #include "vm/vm.h"
 #include "vm/inspect.h"
+#include "threads/thread.h" // 안전하게 struct thread 내부 구조 접근을 위한 선언
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */


### PR DESCRIPTION
**변경 이유**
Pintos 가상 메모리(VM) 시스템의 테스트 케이스 C 소스 파일에 한국어 주석을 추가했습니다.
테스트별 목적 및 코드 이해도를 높이기 위해 수정하였습니다.
    
**주요 변경 사항**
- 기존 영어 주석을 한국어로 번역했습니다.
- 코드 각 라인의 기능 및 로직에 대한 자세한 설명을 한국어 주석으로 추가하여 코드 이해도를 높였습니다.

**대상 폴더 및 파일**
- tests/vm/*.c